### PR TITLE
Setting correct snapshot version.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <groupId>net.jsign</groupId>
   <artifactId>jsign</artifactId>
   <name>Jsign - Code signing for Windows executables</name>
-  <version>1.2</version>
+  <version>1.3-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <inceptionYear>2012</inceptionYear>


### PR DESCRIPTION
I noticed that the current version number used in pom.xml in the master branch is still 1.2. With Maven conventions, this should probably be changed to 1.3-SNAPSHOT and then changed to 1.3 when the 1.3 release is tagged.

Cheers,
Markus