### PR TITLE
Upgrading BouncyCastle version to 1.49.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -45,13 +45,13 @@
     <dependency>
       <groupId>org.bouncycastle</groupId>
       <artifactId>bcprov-jdk15on</artifactId>
-      <version>1.48</version>
+      <version>1.49</version>
     </dependency>
 
     <dependency>
       <groupId>org.bouncycastle</groupId>
       <artifactId>bcpkix-jdk15on</artifactId>
-      <version>1.48</version>
+      <version>1.49</version>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
In my project (signserver.org) we use BouncyCastle version 1.49 and Jsign seems to work fine with that version too as long as it was compiled against it. Feel free to ignore/close this PR in case you don't want to upgrade BC at this point.

Cheers,
Markus