### PR TITLE
Removing shade plugin.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -86,36 +86,6 @@
         </configuration>
       </plugin>
       <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-shade-plugin</artifactId>
-        <version>1.6</version>
-        <executions>
-          <execution>
-            <phase>package</phase>
-            <goals>
-              <goal>shade</goal>
-            </goals>
-            <configuration>
-              <minimizeJar>true</minimizeJar>
-              <filters>
-                <filter>
-                  <artifact>*:*</artifact>
-                  <excludes>
-                    <exclude>META-INF/**</exclude>
-                    <exclude>**/*_de.properties</exclude>
-                  </excludes>
-                </filter>
-              </filters>
-              <transformers>
-                <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
-                  <mainClass>net.jsign.PESignerCLI</mainClass>
-                </transformer>
-              </transformers>
-            </configuration>
-          </execution>
-        </executions>
-      </plugin>
-      <plugin>
         <artifactId>jdeb</artifactId>
         <groupId>org.vafer</groupId>
         <version>1.0</version>


### PR DESCRIPTION
I have had issues with the maven-shade-plugin as it creates a jar with the dependencies included. My project already bundles the dependencies with the application so it does not make sense for us to also have them duplicated in the jsign jar.
In my fork I simply removed the plugin from pom.xml, however maybe there is some other option to have it conditionally included (?).

Not that important but NetBeans IDE also reports this as an issue:
"When the final artifact jar contains classes not originating in current project, NetBeans internal compiler cannot use the sources of the project for compilation. Then changes done in project's source code only appears in depending projects when project is recompiled. Also applies to features like Refactoring which will not be able to find usages in depending projects."

Cheers,
Markus
