### PR TITLE
Specifying plugin version for maven-compiler-plugin.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -80,6 +80,7 @@
     <plugins>
       <plugin>
         <artifactId>maven-compiler-plugin</artifactId>
+        <version>2.3.2</version>
         <configuration>
           <source>1.5</source>
           <target>1.5</target>


### PR DESCRIPTION
The pom.xml is missing plugin version for maven-compile-plugin. This gives the following warning:

    cd /home/user/VersionControlled/github/netmackan/jsign; JAVA_HOME=/usr/lib/jvm/java-1.7.0-openjdk-1.7.0.75-2.5.4.2.fc20.x86_64 /opt/netbeans-8/java/maven/bin/mvn -Dfile.encoding=ISO-8859-1 install
    Scanning for projects...

    Some problems were encountered while building the effective model for net.jsign:jsign:jar:1.2
    'build.plugins.plugin.version' for org.apache.maven.plugins:maven-compiler-plugin is missing. @ line 81, column 15

    It is highly recommended to fix these problems because they threaten the stability of your build.

    For this reason, future Maven versions might no longer support building such malformed projects.
---