### PR TITLE
MavenCentral publishing

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -49,6 +49,17 @@
     </repository>
   </repositories>
 
+  <distributionManagement>
+    <snapshotRepository>
+      <id>ossrh</id>
+      <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+    </snapshotRepository>
+    <repository>
+      <id>ossrh</id>
+      <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
+    </repository>
+  </distributionManagement>
+
   <dependencies>
     <dependency>
       <groupId>commons-cli</groupId>
@@ -141,6 +152,44 @@
                 </transformer>
               </transformers>
             </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.sonatype.plugins</groupId>
+        <artifactId>nexus-staging-maven-plugin</artifactId>
+        <version>1.6.3</version>
+        <extensions>true</extensions>
+        <configuration>
+          <serverId>ossrh</serverId>
+          <nexusUrl>https://oss.sonatype.org/</nexusUrl>
+          <autoReleaseAfterClose>true</autoReleaseAfterClose>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-source-plugin</artifactId>
+        <version>2.2.1</version>
+        <executions>
+          <execution>
+            <id>attach-sources</id>
+            <goals>
+              <goal>jar-no-fork</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-gpg-plugin</artifactId>
+        <version>1.5</version>
+        <executions>
+          <execution>
+            <id>sign-artifacts</id>
+            <phase>verify</phase>
+            <goals>
+              <goal>sign</goal>
+            </goals>
           </execution>
         </executions>
       </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -15,12 +15,26 @@
   </description>
   <url>http://ebourg.github.com/jsign</url>
 
+  <licenses>
+    <license>
+      <name>The Apache Software License, Version 2.0</name>
+      <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+      <distribution>repo</distribution>
+    </license>
+  </licenses>
+
   <developers>
     <developer>
       <name>Emmanuel Bourg</name>
       <email>ebourg@apache.org</email>
     </developer>
   </developers>
+
+  <scm>
+    <url>https://github.com/ebourg/jsign</url>
+    <connection>scm:https://github.com/ebourg/jsign.git</connection>
+    <developerConnection>scm:git://github.com/ebourg/jsign.git</developerConnection>
+  </scm>
 
   <repositories>
     <repository>


### PR DESCRIPTION
I added the required sections to the pom.

One of the parts I struggled with when first publishing to mavencentral was GPG signing.  [I used bintray](https://bintray.com/docs/usermanual/uploads/uploads_syncingartifactswithmavencentral.html) to solve this issue.  The downside is that you have to create a bintray account (but they have GitHub OAuth), and you have to "request inclusion into jcenter" when you create a new project, but once you've done that it's fully automated from there on out.

I'm sure there's other ways to solve this problem too if you prefer :+1: 
