### PR TITLE
Fixing JavaDoc compilation error due to ampersand character.

### DIFF
--- a/src/main/java/net/jsign/pe/DataDirectoryType.java
+++ b/src/main/java/net/jsign/pe/DataDirectoryType.java
@@ -17,7 +17,7 @@
 package net.jsign.pe;
 
 /**
- * Types of structures pointed in the "RVA & Sizes" table (data directory).
+ * Types of structures pointed in the "RVA &amp; Sizes" table (data directory).
  * 
  * @author Emmanuel Bourg
  * @since 1.0


### PR DESCRIPTION
Previously mvn javadoc:jar failed with compilation error due to the character.