### PR TITLE
Add support for specifying signature algorithm and signature provider.

### DIFF
--- a/src/main/java/net/jsign/PESigner.java
+++ b/src/main/java/net/jsign/PESigner.java
@@ -21,6 +21,7 @@ import java.security.KeyStore;
 import java.security.KeyStoreException;
 import java.security.NoSuchAlgorithmException;
 import java.security.PrivateKey;
+import java.security.Provider;
 import java.security.UnrecoverableKeyException;
 import java.security.cert.Certificate;
 import java.security.cert.CertificateEncodingException;
@@ -76,7 +77,10 @@ public class PESigner {
 
     private Certificate[] chain;
     private PrivateKey privateKey;
-    private DigestAlgorithm algo = DigestAlgorithm.getDefault();
+    private DigestAlgorithm digestAlgorithm = DigestAlgorithm.getDefault();
+    private String signatureAlgorithm;
+    private Provider signatureProvider;
+    private String signatureProviderString;
     private String programName;
     private String programURL;
 
@@ -150,8 +154,33 @@ public class PESigner {
      */
     public PESigner withDigestAlgorithm(DigestAlgorithm algorithm) {
         if (algorithm != null) {
-            this.algo = algorithm;
+            this.digestAlgorithm = algorithm;
         }
+        return this;
+    }
+
+    /**
+     * Explicitly sets the signature algorithm to use.
+     */
+    public PESigner withSignatureAlgorithm(String signatureAlgorithm) {
+        this.signatureAlgorithm = signatureAlgorithm;
+        return this;
+    }
+
+    /**
+     * Sets the security provider to use for the signature.
+     */
+    public PESigner withSignatureProvider(Provider provider) {
+        this.signatureProvider = provider;
+        return this;
+    }
+
+    /**
+     * Sets the provider to use for the signature from the security provider
+     * name.
+     */
+    public PESigner withSignatureProvider(String provider) {
+        this.signatureProviderString = provider;
         return this;
     }
 
@@ -182,21 +211,35 @@ public class PESigner {
             if (tsaurlOverride != null) {
                 ts.setURL(tsaurlOverride);
             }
-            sigData = ts.timestamp(algo, sigData);
+            sigData = ts.timestamp(digestAlgorithm, sigData);
         }
         
         return new CertificateTableEntry(sigData);
     }
 
     private CMSSignedData createSignature(PEFile file) throws IOException, CMSException, OperatorCreationException, CertificateEncodingException {
-        byte[] sha = file.computeDigest(algo);
+        byte[] sha = file.computeDigest(digestAlgorithm);
         
-        AlgorithmIdentifier algorithmIdentifier = new AlgorithmIdentifier(algo.oid, DERNull.INSTANCE);
+        AlgorithmIdentifier algorithmIdentifier = new AlgorithmIdentifier(digestAlgorithm.oid, DERNull.INSTANCE);
         DigestInfo digestInfo = new DigestInfo(algorithmIdentifier, sha);
         SpcAttributeTypeAndOptionalValue data = new SpcAttributeTypeAndOptionalValue(AuthenticodeObjectIdentifiers.SPC_PE_IMAGE_DATA_OBJID, new SpcPeImageData());
         SpcIndirectDataContent spcIndirectDataContent = new SpcIndirectDataContent(data, digestInfo);
 
-        ContentSigner shaSigner = new JcaContentSignerBuilder(algo + "with" + privateKey.getAlgorithm()).build(privateKey);
+        // create content signer
+        final String sigAlg;
+        if (signatureAlgorithm == null) {
+            sigAlg = digestAlgorithm + "with" + privateKey.getAlgorithm();
+        } else {
+            sigAlg = signatureAlgorithm;
+        }
+        JcaContentSignerBuilder contentSignerBuilder = new JcaContentSignerBuilder(sigAlg);
+        if (signatureProvider != null) {
+            contentSignerBuilder.setProvider(signatureProvider);
+        } else if (signatureProviderString != null) {
+            contentSignerBuilder.setProvider(signatureProviderString);
+        }
+        ContentSigner shaSigner = contentSignerBuilder.build(privateKey);
+
         DigestCalculatorProvider digestCalculatorProvider = new JcaDigestCalculatorProviderBuilder().build();
         
         // prepare the authenticated attributes

--- a/src/main/java/net/jsign/PESigner.java
+++ b/src/main/java/net/jsign/PESigner.java
@@ -168,19 +168,20 @@ public class PESigner {
     }
 
     /**
-     * Sets the security provider to use for the signature.
+     * Explicitly sets the signature algorithm and provider to use.
      */
-    public PESigner withSignatureProvider(Provider provider) {
-        this.signatureProvider = provider;
+    public PESigner withSignatureAlgorithm(String signatureAlgorithm, String signatureProvider) {
+        this.signatureAlgorithm = signatureAlgorithm;
+        this.signatureProviderString = signatureProvider;
         return this;
     }
 
     /**
-     * Sets the provider to use for the signature from the security provider
-     * name.
+     * Explicitly sets the signature algorithm and provider to use.
      */
-    public PESigner withSignatureProvider(String provider) {
-        this.signatureProviderString = provider;
+    public PESigner withSignatureAlgorithm(String signatureAlgorithm, Provider signatureProvider) {
+        this.signatureAlgorithm = signatureAlgorithm;
+        this.signatureProvider = signatureProvider;
         return this;
     }
 

--- a/src/test/java/net/jsign/PESignerTest.java
+++ b/src/test/java/net/jsign/PESignerTest.java
@@ -20,6 +20,7 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.security.KeyStore;
+import java.security.Security;
 import java.util.HashSet;
 import java.util.List;
 
@@ -295,7 +296,7 @@ public class PESignerTest extends TestCase {
     }
 
     /**
-     * Tests that it is possible to specify a signature algorithm whos name is
+     * Tests that it is possible to specify a signature algorithm who's name is
      * not simply a concatenation of a digest algorithm and the key algorithm.
      *
      * This test also sets the signature provider as a provider supporting
@@ -316,8 +317,7 @@ public class PESignerTest extends TestCase {
             PESigner signer = new PESigner(getKeyStore(), ALIAS, PRIVATE_KEY_PASSWORD)
                     .withTimestamping(false)
                     .withDigestAlgorithm(DigestAlgorithm.SHA1)
-                    .withSignatureAlgorithm("SHA256withRSAandMGF1")
-                    .withSignatureProvider(new BouncyCastleProvider());
+                    .withSignatureAlgorithm("SHA256withRSAandMGF1", new BouncyCastleProvider());
 
             signer.sign(peFile);
 


### PR DESCRIPTION
Before this patch the signature algorithm was assumed to be the digest algorithm with the key algorithm. While this works for simple cases it does not provide support when there are multiple signature algorithms available for a certain key type. For example signature algorithms using RSA keys are both RSASSA-PKCS1_v1.5 (SHAxWithRSA) and RSASSA-PSS (SHAxWithRSAandMGF1).
In addition it is maybe not necessarily so that the same hash algorithm must be used for both the digest in the PE, in the time-stamp token and as the digest of the signature.

This patch adds support for explicitly specifying which signature algorithm to use independent of what digest algorithm is used. It also adds support for specifying which provider that should be used for the signature. This is needed if the provider that should be used is not installed or if there are multiple providers available and one don't want to use the first one in the list.