### PR TITLE
Fix HTTP Accept header to use right content-type for the response

### DIFF
--- a/src/main/java/net/jsign/timestamp/RFC3161Timestamper.java
+++ b/src/main/java/net/jsign/timestamp/RFC3161Timestamper.java
@@ -61,7 +61,7 @@ public class RFC3161Timestamper extends Timestamper {
         conn.setRequestMethod("POST");
         conn.setRequestProperty("Content-type", "application/timestamp-query");
         conn.setRequestProperty("Content-length", String.valueOf(request.length));
-        conn.setRequestProperty("Accept", "application/timestamp-query");
+        conn.setRequestProperty("Accept", "application/timestamp-reply");
         conn.setRequestProperty("User-Agent", "Transport");
         
         conn.getOutputStream().write(request);


### PR DESCRIPTION
Noticed that the TSP client code sets the MIME type for the request also in the "Accept" header but it should instead contain the MIME type for the expected response.

The response MIME type should be "application/timestamp-reply" according to RFC#3161 and as clarified in its errata.