### PR TITLE
Correct a file descriptor leak in PEFile

### DIFF
--- a/jsign-core/src/main/java/net/jsign/pe/PEFile.java
+++ b/jsign-core/src/main/java/net/jsign/pe/PEFile.java
@@ -54,33 +54,40 @@ public class PEFile implements Closeable {
     /** The position of the PE header in the file */
     private final long peHeaderOffset;
 
-    private final File file;
-    private final ExtendedRandomAccessFile raf;
+    private final File file = null;
+    private final ExtendedRandomAccessFile raf = null;
 
     public PEFile(File file) throws IOException {
-        this.file = file;
-        raf = new ExtendedRandomAccessFile(file, "rw");
-        
-        // DOS Header
-        
-        byte[] buffer = new byte[2];
-        raf.read(buffer);
-        
-        if (!Arrays.equals(buffer, "MZ".getBytes())) {
-            throw new IOException("DOS header signature not found");
-        }
-        
-        raf.seek(0x3C);
-        peHeaderOffset = raf.readDWord();
-        
-        // PE Header
-        
-        raf.seek(peHeaderOffset);
-        
-        buffer = new byte[4];
-        raf.read(buffer);
-        if (!Arrays.equals(buffer, new byte[] { 'P', 'E', 0, 0})) {
-            throw new IOException("PE signature not found as expected at offset 0x" + Long.toHexString(peHeaderOffset));
+        try {
+			this.file = file;
+			raf = new ExtendedRandomAccessFile(file, "rw");
+		
+			// DOS Header
+		
+			byte[] buffer = new byte[2];
+			raf.read(buffer);
+		
+			if (!Arrays.equals(buffer, "MZ".getBytes())) {
+				throw new IOException("DOS header signature not found");
+			}
+		
+			raf.seek(0x3C);
+			peHeaderOffset = raf.readDWord();
+		
+			// PE Header
+		
+			raf.seek(peHeaderOffset);
+		
+			buffer = new byte[4];
+			raf.read(buffer);
+			if (!Arrays.equals(buffer, new byte[] { 'P', 'E', 0, 0})) {
+				throw new IOException("PE signature not found as expected at offset 0x" + Long.toHexString(peHeaderOffset));
+			}
+        } catch (IOException e) {
+        	if (raf != null) {
+        		raf.close();
+        	}
+        	throw e;
         }
     }
 

--- a/jsign-core/src/main/java/net/jsign/pe/PEFile.java
+++ b/jsign-core/src/main/java/net/jsign/pe/PEFile.java
@@ -54,40 +54,40 @@ public class PEFile implements Closeable {
     /** The position of the PE header in the file */
     private final long peHeaderOffset;
 
-    private final File file = null;
-    private final ExtendedRandomAccessFile raf = null;
+    private File file = null;
+    private ExtendedRandomAccessFile raf = null;
 
     public PEFile(File file) throws IOException {
         try {
-			this.file = file;
-			raf = new ExtendedRandomAccessFile(file, "rw");
-		
-			// DOS Header
-		
-			byte[] buffer = new byte[2];
-			raf.read(buffer);
-		
-			if (!Arrays.equals(buffer, "MZ".getBytes())) {
-				throw new IOException("DOS header signature not found");
-			}
-		
-			raf.seek(0x3C);
-			peHeaderOffset = raf.readDWord();
-		
-			// PE Header
-		
-			raf.seek(peHeaderOffset);
-		
-			buffer = new byte[4];
-			raf.read(buffer);
-			if (!Arrays.equals(buffer, new byte[] { 'P', 'E', 0, 0})) {
-				throw new IOException("PE signature not found as expected at offset 0x" + Long.toHexString(peHeaderOffset));
-			}
+            this.file = file;
+            raf = new ExtendedRandomAccessFile(file, "rw");
+
+            // DOS Header
+
+            byte[] buffer = new byte[2];
+            raf.read(buffer);
+
+            if (!Arrays.equals(buffer, "MZ".getBytes())) {
+                throw new IOException("DOS header signature not found");
+            }
+
+            raf.seek(0x3C);
+            peHeaderOffset = raf.readDWord();
+
+            // PE Header
+
+            raf.seek(peHeaderOffset);
+
+            buffer = new byte[4];
+            raf.read(buffer);
+            if (!Arrays.equals(buffer, new byte[] { 'P', 'E', 0, 0})) {
+                throw new IOException("PE signature not found as expected at offset 0x" + Long.toHexString(peHeaderOffset));
+            }
         } catch (IOException e) {
-        	if (raf != null) {
-        		raf.close();
-        	}
-        	throw e;
+            if (raf != null) {
+                raf.close();
+            }
+            throw e;
         }
     }
 


### PR DESCRIPTION
This corrects a problem encountered when the PEFile tries to work on an invalid PEFile causing the constructor to fail without closing the `raf` handle. Otherwise, the system can run out of file descriptors if this error happens enough times.