### PR TITLE
Verify method implemented

### DIFF
--- a/jsign-core/src/main/java/net/jsign/pe/VerificationException.java
+++ b/jsign-core/src/main/java/net/jsign/pe/VerificationException.java
@@ -1,0 +1,12 @@
+package net.jsign.pe;
+
+public class VerificationException extends Exception {
+
+    public VerificationException(String message) {
+        super(message);
+    }
+
+    public VerificationException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}


### PR DESCRIPTION
A verification method has been implemented, which is in the TODO list.

After I couldn't find the cause of the exception: 
**Exception in thread "main" java.lang.NullPointerException 
at org.bouncycastle.cms.CMSSignedData$1.write(Unknown Source)** 
pointed by issue #42, implemented this verify method.

This is a shallow verify, if the exe file contains a chain of certificates, only the leaf certificates and their counter-signatures are verified. 

Check [this](https://www.ietf.org/rfc/rfc2315.txt) to understand the implementation.