### PR TITLE
Fix faulty merge of the PowerShell signing PR (#64, #65)

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -270,7 +270,8 @@ are provided to install it easily on most Linux distributions. On these systems 
 
 <pre>
   usage: jsign [OPTIONS] FILE
-  Sign and timestamp a Windows executable file.
+  Sign and timestamp a Windows executable file, a Microsoft Installer (MSI) or a
+  PowerShell script.
   
   -s,--keystore &lt;FILE>       The keystore file, or the SunPKCS11 configuration file
      --storepass &lt;PASSWORD>  The password to open the keystore
@@ -278,25 +279,29 @@ are provided to install it easily on most Linux distributions. On these systems 
                              - JKS: Java keystore (.jks files)
                              - PKCS12: Standard PKCS#12 keystore (.p12 or .pfx files)
                              - PKCS11: PKCS#11 hardware token
-  -a,--alias &lt;NAME>          The alias of the certificate used for signing in the keystore.
+  -a,--alias &lt;NAME>          The alias of the certificate used for signing in the
+                             keystore.
      --keypass &lt;PASSWORD>    The password of the private key. When using a keystore,
                              this parameter can be omitted if the keystore shares the
                              same password.
-     --keyfile &lt;FILE>        The file containing the private key (supports PEM &amp; PVK files)
+     --keyfile &lt;FILE>        The file containing the private key. PEM and PVK files
+                             are supported.
   -c,--certfile &lt;FILE>       The file containing the PKCS#7 certificate chain
                              (.p7b or .spc files).
   -d,--alg &lt;ALGORITHM>       The digest algorithm (SHA-1, SHA-256, SHA-384 or SHA-512)
   -t,--tsaurl &lt;URL>          The URL of the timestamping authority.
   -m,--tsmode &lt;MODE>         The timestamping mode (RFC3161 or Authenticode)
   -r,--tsretries &lt;NUMBER>    The number of retries for timestamping
-  -w,--tsretrywait &lt;SECONDS> The number of seconds to wait between timestamping retries
+  -w,--tsretrywait &lt;SECONDS> The number of seconds to wait between timestamping
+                             retries
   -n,--name &lt;NAME>           The name of the application
   -u,--url &lt;URL>             The URL of the application
      --proxyUrl &lt;URL>        The URL of the HTTP proxy
      --proxyUser &lt;NAME>      The user for the HTTP proxy. If an user is needed.
-     --proxyPass &lt;PASSWORD>  The password for the HTTP proxy user. If an user is needed.
+     --proxyPass &lt;PASSWORD>  The password for the HTTP proxy user. If an user is
+                             needed.
      --replace               Tells if previous signatures should be replaced.
-     --encoding &lt;ENCODING>   The encoding of the PowerShell script to be signed (UTF-8
+  -e,--encoding &lt;ENCODING>   The encoding of the PowerShell script to be signed (UTF-8
                              by default).
   -h,--help                  Print the help
 </pre>

--- a/jsign-core/src/main/java/net/jsign/SignerHelper.java
+++ b/jsign-core/src/main/java/net/jsign/SignerHelper.java
@@ -434,7 +434,7 @@ class SignerHelper {
         try (FileInputStream in = new FileInputStream(file)) {
             CertificateFactory certificateFactory = CertificateFactory.getInstance("X.509");
             Collection<? extends Certificate> certificates = certificateFactory.generateCertificates(in);
-            return certificates.toArray(new Certificate[certificates.size()]);
+            return certificates.toArray(new Certificate[0]);
         }
     }
 

--- a/jsign-core/src/main/java/net/jsign/powershell/PowerShellScript.java
+++ b/jsign-core/src/main/java/net/jsign/powershell/PowerShellScript.java
@@ -57,6 +57,10 @@ public class PowerShellScript {
             "(?<signatureBlock>.*)" +
             "# SIG # End signature block\\r\\n");
 
+    private static final Pattern SIGNATURE_BLOCK_REMOVAL_PATTERN = Pattern.compile("(?s)" +
+            "\\r?\\n" +
+            "# SIG # Begin signature block.*$");
+
     private File file;
     private String content;
     private Charset encoding;
@@ -205,7 +209,7 @@ public class PowerShellScript {
      * @return the content without the signature
      */
     private String getContentWithoutSignatureBlock() {
-        return SIGNATURE_BLOCK_PATTERN.matcher(getContent()).replaceFirst("");
+        return SIGNATURE_BLOCK_REMOVAL_PATTERN.matcher(getContent()).replaceAll("");
     }
 
     public byte[] computeDigest(MessageDigest digest) {

--- a/jsign-core/src/test/java/net/jsign/PESignerTest.java
+++ b/jsign-core/src/test/java/net/jsign/PESignerTest.java
@@ -109,7 +109,7 @@ public class PESignerTest {
         try (FileInputStream in = new FileInputStream(new File("target/test-classes/keystores/jsign-test-certificate-full-chain.spc"))) {
             CertificateFactory certificateFactory = CertificateFactory.getInstance("X.509");
             Collection<? extends Certificate> certificates = certificateFactory.generateCertificates(in);
-            chain = certificates.toArray(new Certificate[certificates.size()]);
+            chain = certificates.toArray(new Certificate[0]);
         }
         
         PrivateKey key = PrivateKeyUtils.load(new File("target/test-classes/keystores/privatekey-encrypted.pvk"), "password");
@@ -162,7 +162,7 @@ public class PESignerTest {
         try (FileInputStream in = new FileInputStream(new File("target/test-classes/keystores/jsign-root-ca.pem"))) {
             CertificateFactory certificateFactory = CertificateFactory.getInstance("X.509");
             Collection<? extends Certificate> certificates = certificateFactory.generateCertificates(in);
-            chain = certificates.toArray(new Certificate[certificates.size()]);
+            chain = certificates.toArray(new Certificate[0]);
         }
         
         PrivateKey key = PrivateKeyUtils.load(new File("target/test-classes/keystores/privatekey-encrypted.pvk"), "password");

--- a/jsign/src/deb/data/usr/share/man/man1/jsign.1
+++ b/jsign/src/deb/data/usr/share/man/man1/jsign.1
@@ -108,7 +108,7 @@ The password for the HTTP proxy user. If an user is needed.
 Tells if previous signatures should be replaced. By default the new signature is appended to the existing ones.
 
 .TP
-.B --encoding <ENCODING>
+.B -e, --encoding <ENCODING>
 The encoding of the PowerShell script to be signed (UTF-8 by default).
 
 .TP


### PR DESCRIPTION
It is nice that you attributed the commit to me, despite the significant changes you had to do.
It is not so nice, that you introduced several major bugs that are now attributed to me too now. :-(

For example you cannot sign a PowerShell script through the CLI, because if you do not provide a script encoding it does not use UTF-8 as documented, but produces a `NullPointerException` and you cannot give an encoding explicitly either, as the parameter does not have an argument for the actual encoding anymore.

You also removed all doc-changes and changes to bash completion.
And you made it impossible to set the script encoding via API as you made the method package private.

But on my way to fix the faulty merge, I also caught two other bugs, so maybe it was worth the hassle. :-D
I hope I got all merge errors with this PR.

Btw. when do you plan to release v3, as we soon want / need to sign PowerShell scripts and I'd prefer using an official version. :-)