### PR TITLE
--alias option optional if keystore contains only one alias

### DIFF
--- a/jsign-core/src/main/java/net/jsign/SignerHelper.java
+++ b/jsign-core/src/main/java/net/jsign/SignerHelper.java
@@ -41,6 +41,7 @@ import java.security.cert.CertificateException;
 import java.security.cert.CertificateFactory;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Enumeration;
 import java.util.List;
 
 import net.jsign.timestamp.TimestampingMode;
@@ -283,7 +284,20 @@ class SignerHelper {
             }
 
             if (alias == null) {
-                throw new SignerException("alias " + parameterName + " must be set");
+                try {
+                    Enumeration<String> aliases = ks.aliases();
+                    while (aliases.hasMoreElements()) {
+                        if (alias != null) {
+                            throw new SignerException("alias " + parameterName + " must be set because the keystore contains more than one alias");
+                        }
+                        alias = aliases.nextElement();
+                    }
+                } catch (KeyStoreException e) {
+                    throw new SignerException("Failed to enumerate the aliases in the keystore. Use the alias " + parameterName + " instead");
+                }
+                if (alias == null) {
+                    throw new SignerException("no aliases found in keystore");
+                }
             }
 
             try {

--- a/jsign/src/deb/data/usr/share/man/man1/jsign.1
+++ b/jsign/src/deb/data/usr/share/man/man1/jsign.1
@@ -45,7 +45,8 @@ This options is not required if the keystore has a known extension (.jks, .p12 o
 .TP
 .B -a, --alias <NAME>
 The alias of the certificate used for signing in the keystore. This option
-is mandatory in the keystore option is specified.
+is mandatory in the keystore option is specified and if the keystore contains more
+that one alias.
 
 .TP
 .B --keypass <PASSWORD>


### PR DESCRIPTION
If the keystore contains only one alias, what about making the `--alias` CLI option optional? We can retrieve it from the keystore itself...