### PR TITLE
Fix for checksum update and calculation

### DIFF
--- a/jsign-core/src/main/java/net/jsign/pe/PEFile.java
+++ b/jsign-core/src/main/java/net/jsign/pe/PEFile.java
@@ -511,6 +511,7 @@ public class PEFile implements Signable, Closeable {
             int len;
             while ((len = channel.read(b)) > 0) {
                 checksum.update(b.array(), 0, len);
+                b.clear();
             }
         } catch (IOException e) {
             throw new RuntimeException(e);
@@ -524,6 +525,8 @@ public class PEFile implements Signable, Closeable {
         buffer.order(ByteOrder.LITTLE_ENDIAN);
         buffer.putInt((int) computeChecksum());
         
+        buffer.position(0);
+
         try {
             channel.position(peHeaderOffset + 88);
             channel.write(buffer);


### PR DESCRIPTION
Two fixes as discussed in #77 :
* Position the buffer so that it will be written out to the checksum field. This solves the issue with the field not being updated.
* Clear the buffer so that it can be used for the next read. This solves the issue with incorrect checksum calculation for files larger than the buffer (64 KiB).