### PR TITLE
Use key path instead of key name for google signer

### DIFF
--- a/jsign-core/src/main/java/net/jsign/SignerHelper.java
+++ b/jsign-core/src/main/java/net/jsign/SignerHelper.java
@@ -321,7 +321,7 @@ class SignerHelper {
             String[] elements = storepass.split("\\|");
             provider = new SigningServiceJcaProvider(new DigiCertOneSigningService(elements[0], new File(elements[1]), elements[2]));
         } else if ("GOOGLECLOUD".equals(storetype)) {
-            provider = new SigningServiceJcaProvider(new GoogleCloudSigningService(keystore.getName(), storepass, alias -> {
+            provider = new SigningServiceJcaProvider(new GoogleCloudSigningService(keystore.getPath(), storepass, alias -> {
                 try {
                     return loadCertificateChain(certfile);
                 } catch (IOException | CertificateException e) {


### PR DESCRIPTION
Fixing https://github.com/ebourg/jsign/issues/91