### PR TITLE
Improve MAVEN build Performance

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ matrix:
     - jdk: openjdk-ea
 
 after_success:
-  - mvn clean test jacoco:report-aggregate coveralls:report
+  - mvn -T 1C clean test jacoco:report-aggregate coveralls:report
 
 cache:
   directories:

--- a/pom.xml
+++ b/pom.xml
@@ -116,6 +116,7 @@
         <version>2.22.2</version>
         <configuration>
           <failIfNoTests>false</failIfNoTests>
+          <parallel>all</parallel>
         </configuration>
       </plugin>
       <plugin>


### PR DESCRIPTION

[Parallel builds in Maven 3](https://cwiki.apache.org/confluence/display/MAVEN/Parallel+builds+in+Maven+3) Maven 3.x has the capability to perform parallel builds.

[Apache Maven Dependency Plugin](https://maven.apache.org/plugins/maven-dependency-plugin/index.html) can be used to find unused dependencies. And I found following list. Maybe we can remove them.
jsign-parent
jsign-core
{groupId='org.mockito', artifactId='mockito-all'}
jsign-ant
jsign-cli
{groupId='org.mockito', artifactId='mockito-all'}
jsign
{groupId='net.jsign', artifactId='jsign-core'}
{groupId='junit', artifactId='junit'}
{groupId='org.mockito', artifactId='mockito-all'}
jsign-maven-plugin
{groupId='org.apache.maven', artifactId='maven-core'}
{groupId='org.apache.maven.plugin-testing', artifactId='maven-plugin-testing-harness'}
{groupId='org.apache.maven', artifactId='maven-compat'}
jsign-gradle-plugin
{groupId='org.gradle', artifactId='gradle-native'}
{groupId='org.gradle', artifactId='gradle-process-services'}


According to [Maven parallel test](https://www.baeldung.com/maven-junit-parallel-tests), we can run tests in parallel.

=====================
If there are any inappropriate modifications in this PR, please give me a reply and I will change them.
