### PR TITLE
Make proguard keep enum fields.

### DIFF
--- a/jsign/pom.xml
+++ b/jsign/pom.xml
@@ -149,6 +149,7 @@
                 <option>-keep public class net.jsign.script.* { *; }</option>
                 <option>-keep public class net.jsign.timestamp.* { *; }</option>
                 <option>-keeppackagenames net.jsign</option>
+                <option>-keepclassmembers class * extends java.lang.Enum { *; }</option>
               </options>
               <injar>${project.build.finalName}.jar</injar>
               <includeDependency>false</includeDependency>


### PR DESCRIPTION
We tried building the JSIGN utility from master because the out of memory fix is not yet released. For builds with the master branch, signing commands fail because proguard is not retaining the enum field information when it optimizes the build. This causes an exception like below that breaks functionality:

```
13:53:27  Picked up JAVA_TOOL_OPTIONS: -Dfile.encoding=UTF-8 -Dsun.jnu.encoding=UTF-8
13:53:27  Exception in thread "main" java.lang.ExceptionInInitializerError
13:53:27       at org.apache.logging.log4j.Level.<clinit>(Level.java:98)
13:53:27       at org.apache.logging.log4j.status.StatusLogger.<init>(StatusLogger.java:108)
13:53:27       at org.apache.logging.log4j.status.StatusLogger.<clinit>(StatusLogger.java:85)
13:53:27       at org.apache.logging.log4j.LogManager.<clinit>(LogManager.java:61)
13:53:27       at net.jsign.poi.poifs.filesystem.POIFSFileSystem.<clinit>(POIFSFileSystem.java:67)
13:53:27       at net.jsign.msi.MSIFile.<init>(MSIFile.java:113)
13:53:27       at net.jsign.Signable.of(Signable.java:112)
13:53:27       at net.jsign.SignerHelper.sign(SignerHelper.java:496)
13:53:27       at net.jsign.JsignCLI.execute(JsignCLI.java:116)
13:53:27       at net.jsign.JsignCLI.main(JsignCLI.java:40)
13:53:27  Caused by: java.lang.ClassCastException: class org.apache.logging.log4j.spi.StandardLevel not an enum
13:53:27       at java.util.EnumSet.noneOf(EnumSet.java:112)
13:53:27       at java.util.EnumSet.allOf(EnumSet.java:131)
13:53:27       at org.apache.logging.log4j.spi.StandardLevel.<clinit>(StandardLevel.java:66)
13:53:27       ... 10 more
```

This code fix tells proguard to retain enum information so that log4j doesn't break while running.