### PR TITLE
Fix name of cert for DigiCert test

### DIFF
--- a/jsign-core/src/test/java/net/jsign/SignerHelperTest.java
+++ b/jsign-core/src/test/java/net/jsign/SignerHelperTest.java
@@ -196,7 +196,7 @@ public class SignerHelperTest {
         SignerHelper helper = new SignerHelper(new StdOutConsole(1), "option")
                 .storetype("DIGICERTONE")
                 .storepass(apikey + "|" + DigiCertONE.getClientCertificateFile() + "|" + DigiCertONE.getClientCertificatePassword())
-                .alias("Tomcat-PMC-cert-2021-04")
+                .alias("Tomcat-PMC-cert-2021-11")
                 .alg("SHA-256");
 
         helper.sign(targetFile);


### PR DESCRIPTION
The Tomcat certificate has been renewed / replaced. Update to use the new certificate name.