### PR TITLE
Fix attaching signatures for PE files

### DIFF
--- a/jsign-core/src/main/java/net/jsign/SignerHelper.java
+++ b/jsign-core/src/main/java/net/jsign/SignerHelper.java
@@ -547,6 +547,14 @@ class SignerHelper {
                 return;
             } catch (Exception e) {
                 throw new SignerException("Couldn't attach the signature to " + file, e);
+            } finally {
+                try {
+                    if (signable instanceof Closeable) {
+                        ((Closeable) signable).close();
+                    }
+                } catch (IOException ioe) {
+                    // Ignore for now
+                }
             }
         }
 

--- a/jsign-core/src/main/java/net/jsign/SignerHelper.java
+++ b/jsign-core/src/main/java/net/jsign/SignerHelper.java
@@ -59,6 +59,7 @@ import net.jsign.jca.DigiCertOneSigningService;
 import net.jsign.jca.ESignerSigningService;
 import net.jsign.jca.GoogleCloudSigningService;
 import net.jsign.jca.SigningServiceJcaProvider;
+import net.jsign.pe.PEFile;
 import net.jsign.timestamp.TimestampingMode;
 
 /**
@@ -575,6 +576,11 @@ class SignerHelper {
         CMSSignedData signedData = new CMSSignedData((CMSProcessable) null, ContentInfo.getInstance(new ASN1InputStream(signatureBytes).readObject()));
 
         Signable signable = Signable.of(file, encoding);
+        
+        if (signable instanceof PEFile) {
+            ((PEFile) signable).pad(8);
+        }
+        
         try {
             signable.setSignature(signedData);
             signable.save();


### PR DESCRIPTION
I spotted this testing repeatable builds with Apache Tomcat. This might not be the right way to fix the issue generally but it does fix the issue I was seeing. In short, when re-attaching the signature the PE file needs to be padded to a multiple of 8 bytes first - just like it is when signing the PE file directly.