### PR TITLE
Added support for using Google Cloud KMS via Hashicorp Vault

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -180,6 +180,7 @@ programmatically or standalone as a command line tool.</p>
           <li><code>DIGICERTONE</code>: DigiCert ONE Secure Software Manager</li>
           <li><code>ESIGNER</code>: SSL.com eSigner</li>
           <li><code>GOOGLECLOUD</code>: Google Cloud KMS</li>
+          <li><code>VAULT_GOOGLECLOUD</code>: Google Cloud KMS via Hashicorp Vault</li>
         </ul>
       </td>
       <td class="required">No, automatically detected for file based keystores.</td>
@@ -448,6 +449,7 @@ are provided to install it easily on most Linux distributions. On these systems 
                              - DIGICERTONE: DigiCert ONE Secure Software Manager
                              - ESIGNER: SSL.com eSigner
                              - GOOGLECLOUD: Google Cloud KMS
+                             - VAULT_GOOGLECLOUD: Google Cloud KMS via Hashicorp Vault
   -a,--alias &lt;NAME>          The alias of the certificate used for signing in the keystore.
      --keypass &lt;PASSWORD>    The password of the private key. When using a keystore,
                              this parameter can be omitted if the keystore shares the
@@ -599,6 +601,17 @@ the version is omitted the most recent one will be picked automatically.</p>
  jsign --storetype GOOGLECLOUD --storepass &lt;api-access-token&gt; \
        --keystore projects/first-rain-123/locations/global/keyRings/mykeyring \
        --alias test --certfile full-chain.pem application.exe
+</pre>
+
+<h4 id="example-googlecloud-vault">Example using Google Cloud KMS via Hashicorp Vault:</h4>
+
+<p>Google Cloud KMS stores only the private key, the certificate must be provided separately. The keystore parameter
+references the URL of the Vault secret engine, consisting of the Vault server URL, the API version v1 and the secrets engine path.
+The alias specifies the name of the key in Vault and the key version in Google Cloud separated by a colon character.</p>
+
+<pre>
+ jsign --storetype VAULT_GOOGLECLOUD --storepass &lt;vault-token&gt; \
+       --keystore https://vault.example.com/v1/gcpkms --alias test:1 --certfile full-chain.pem application.exe
 </pre>
 
 

--- a/jsign-cli/src/main/java/net/jsign/JsignCLI.java
+++ b/jsign-cli/src/main/java/net/jsign/JsignCLI.java
@@ -68,7 +68,8 @@ public class JsignCLI {
                         + "- AZUREKEYVAULT: Azure Key Vault key management system\n"
                         + "- DIGICERTONE: DigiCert ONE Secure Software Manager\n"
                         + "- ESIGNER: SSL.com eSigner\n"
-                        + "- GOOGLECLOUD: Google Cloud KMS\n").build());
+                        + "- GOOGLECLOUD: Google Cloud KMS\n"
+                        + "- VAULT_GOOGLECLOUD: Google Cloud KMS via Hashicorp Vault\n").build());
         options.addOption(Option.builder("a").hasArg().longOpt(PARAM_ALIAS).argName("NAME").desc("The alias of the certificate used for signing in the keystore.").build());
         options.addOption(Option.builder().hasArg().longOpt(PARAM_KEYPASS).argName("PASSWORD").desc("The password of the private key. When using a keystore, this parameter can be omitted if the keystore shares the same password.").build());
         options.addOption(Option.builder().hasArg().longOpt(PARAM_KEYFILE).argName("FILE").desc("The file containing the private key. PEM and PVK files are supported. ").type(File.class).build());

--- a/jsign-core/src/main/java/net/jsign/jca/VaultGoogleCloudSigningService.java
+++ b/jsign-core/src/main/java/net/jsign/jca/VaultGoogleCloudSigningService.java
@@ -1,0 +1,136 @@
+/**
+ * Copyright 2023 Maria Merkel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.jsign.jca;
+
+import com.cedarsoftware.util.io.JsonWriter;
+import net.jsign.DigestAlgorithm;
+
+import java.io.IOException;
+import java.security.GeneralSecurityException;
+import java.security.KeyStoreException;
+import java.security.UnrecoverableKeyException;
+import java.security.cert.Certificate;
+import java.util.Arrays;
+import java.util.Base64;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+
+public class VaultGoogleCloudSigningService implements SigningService {
+
+    private final Function<String, Certificate[]> certificateStore;
+
+    /** Cache of private keys indexed by id */
+    private final Map<String, SigningServicePrivateKey> keys = new HashMap<>();
+
+    private final RESTClient client;
+
+    /**
+     * Creates a new Vault Google Cloud signing service.
+     *
+     * @param engineURL        the URL of the Vault secrets engine
+     * @param token            the Vault token
+     * @param certificateStore provides the certificate chain for the keys
+     */
+    public VaultGoogleCloudSigningService(String engineURL, String token, Function<String, Certificate[]> certificateStore) {
+        this.certificateStore = certificateStore;
+        this.client = new RESTClient(engineURL.endsWith("/") ? engineURL : engineURL + "/", conn -> conn.setRequestProperty("Authorization", "Bearer " + token));
+    }
+
+    @Override
+    public String getName() {
+        return "Vault_GoogleCloud";
+    }
+
+    /**
+     * Returns the list of key names available in the secrets engine.
+     *
+     * NOTE: This will return the key name only, not the key name and version. Vault does not provide a function to retrieve
+     * the key version. The key version will need to be appended to the key name when using the key.
+     *
+     * @return list of key names
+     */
+    @Override
+    public List<String> aliases() throws KeyStoreException {
+        List<String> aliases;
+
+        try {
+            Map<String, ?> response = client.get("keys?list=true");
+            String[] keys = ((Map<String, String[]>) response.get("data")).get("keys");
+            aliases = Arrays.asList(keys);
+        } catch (IOException e) {
+            throw new KeyStoreException(e);
+        }
+
+        return aliases;
+    }
+
+    @Override
+    public Certificate[] getCertificateChain(String alias) throws KeyStoreException {
+        return certificateStore.apply(alias);
+    }
+
+    @Override
+    public SigningServicePrivateKey getPrivateKey(String alias, char[] password) throws UnrecoverableKeyException {
+        if (keys.containsKey(alias)) {
+            return keys.get(alias);
+        }
+
+        if (!alias.contains(":")) throw new UnrecoverableKeyException("Unable to fetch Vault Google Cloud private key '" + alias + "' (missing key version)");
+
+        String algorithm;
+
+        try {
+            Map<String, ?> response = client.get("keys/" + alias.substring(0, alias.indexOf(":")));
+            algorithm = ((Map<String, String>) response.get("data")).get("algorithm");
+        } catch (IOException e) {
+            throw (UnrecoverableKeyException) new UnrecoverableKeyException("Unable to fetch Vault Google Cloud private key '" + alias + "'").initCause(e);
+        }
+
+        algorithm = algorithm.substring(0, algorithm.indexOf("_")).toUpperCase();
+
+        SigningServicePrivateKey key = new SigningServicePrivateKey(alias, algorithm);
+        keys.put(alias, key);
+        return key;
+    }
+
+    @Override
+    public byte[] sign(SigningServicePrivateKey privateKey, String algorithm, byte[] data) throws GeneralSecurityException {
+        DigestAlgorithm digestAlgorithm = DigestAlgorithm.of(algorithm.substring(0, algorithm.toLowerCase().indexOf("with")));
+        data = digestAlgorithm.getMessageDigest().digest(data);
+
+        String alias = privateKey.getId();
+        String keyName = alias.substring(0, alias.indexOf(":"));
+        String keyVersion = alias.substring(alias.indexOf(":") + 1);
+
+        Map<String, Object> request = new HashMap<>();
+        request.put("key_version", keyVersion);
+        request.put("digest", Base64.getEncoder().encodeToString(data));
+
+        try {
+            Map<String, Object> args = new HashMap<>();
+            args.put(JsonWriter.TYPE, "false");
+            Map<String, ?> response = client.post("sign/" + keyName, JsonWriter.objectToJson(request, args));
+            String signature = ((Map<String, String>) response.get("data")).get("signature");
+
+            return Base64.getDecoder().decode(signature);
+        } catch (IOException e) {
+            throw new GeneralSecurityException(e);
+        }
+    }
+}

--- a/jsign/src/deb/data/usr/share/bash-completion/completions/jsign
+++ b/jsign/src/deb/data/usr/share/bash-completion/completions/jsign
@@ -22,7 +22,7 @@ _jsign()
             return 0
             ;;
         --storetype)
-            COMPREPLY=( $( compgen -W 'JKS JCEKS PKCS12 PKCS11 AWS AZUREKEYVAULT DIGICERTONE ESIGNER GOOGLECLOUD YUBIKEY NITROKEY OPENPGP OPENSC' -- "$cur" ) )
+            COMPREPLY=( $( compgen -W 'JKS JCEKS PKCS12 PKCS11 AWS AZUREKEYVAULT DIGICERTONE ESIGNER GOOGLECLOUD VAULT_GOOGLECLOUD YUBIKEY NITROKEY OPENPGP OPENSC' -- "$cur" ) )
             return 0
             ;;
         --storepass|-a|--alias|--keypass|-t|--tsaurl|-r|--tsretries|-w|--tsretrywait|-n|--name|-u|--url|-e|--encoding)

--- a/jsign/src/deb/data/usr/share/man/man1/jsign.1
+++ b/jsign/src/deb/data/usr/share/man/man1/jsign.1
@@ -64,6 +64,8 @@ The type of the keystore:
 .br
 - GOOGLECLOUD   : Google Cloud KMS
 .br
+- VAULT_GOOGLECLOUD : Google Cloud KMS via Hashicorp Vault
+.br
 This option is not required for file based keystores (JKS, JCEKS and PKCS12).
 
 .TP
@@ -291,6 +293,15 @@ the version is omitted the most recent one will be picked automatically.
 jsign --storetype GOOGLECLOUD --storepass <api-access-token> \\
       --keystore projects/first-rain-123/locations/global/keyRings/mykeyring \\
       --alias test --certfile full-chain.pem application.exe
+
+Signing with Google Cloud KMS via Hashicorp Vault:
+
+Google Cloud KMS stores only the private key, the certificate must be provided separately. The keystore parameter
+references the URL of the Vault secret engine, consisting of the Vault server URL, the API version v1 and the secrets engine path.
+The alias specifies the name of the key in Vault and the key version in Google Cloud separated by a colon character.
+
+jsign --storetype VAULT_GOOGLECLOUD --storepass <vault-token> \
+      --keystore https://vault.example.com/v1/gcpkms --alias test:1 --certfile full-chain.pem application.exe
 
 
 .SH REPORTING BUGS


### PR DESCRIPTION
This PR enables support for using Google Cloud KMS via Hashicorp Vault via the [Vault Google Cloud KMS secrets engine](https://developer.hashicorp.com/vault/docs/secrets/gcpkms).

Using this instead of the direct Google Cloud KMS integration is useful in some applications where the additional authentication, policy or auditing features of Vault are required. I have added support to JSign CLI to use the service with a Vault token, but in practice the more likely application is for automated usage, where the application obtains a temporary token via another authentication method (such as client certificate authentication) and then passes it to JSign.