### PR TITLE
ECC broken with AWS KMS

### DIFF
--- a/jsign-core/src/main/java/net/jsign/jca/AmazonSigningService.java
+++ b/jsign-core/src/main/java/net/jsign/jca/AmazonSigningService.java
@@ -156,8 +156,9 @@ public class AmazonSigningService implements SigningService {
 
             String keySpec = (String) keyMetadata.get("KeySpec");
             algorithm = keySpec.substring(0, keySpec.indexOf('_'));
-            if ("ECC".equals(algorithm))
+            if ("ECC".equals(algorithm)) {
                 algorithm = "EC";
+            }
         } catch (IOException e) {
             throw (UnrecoverableKeyException) new UnrecoverableKeyException("Unable to fetch AWS key '" + alias + "'").initCause(e);
         }

--- a/jsign-core/src/main/java/net/jsign/jca/AmazonSigningService.java
+++ b/jsign-core/src/main/java/net/jsign/jca/AmazonSigningService.java
@@ -156,6 +156,8 @@ public class AmazonSigningService implements SigningService {
 
             String keySpec = (String) keyMetadata.get("KeySpec");
             algorithm = keySpec.substring(0, keySpec.indexOf('_'));
+            if ("ECC".equals(algorithm))
+                algorithm = "EC";
         } catch (IOException e) {
             throw (UnrecoverableKeyException) new UnrecoverableKeyException("Unable to fetch AWS key '" + alias + "'").initCause(e);
         }


### PR DESCRIPTION
Simple fix to solve issue #150.
Tested successfully with a self-signed certificate and a `ECC_NIST_P256` key in AWS KMS.