### PR TITLE
Query IMDSv2 on AWS EC2 to get credentials for KMS if no storepass parameter

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -543,10 +543,14 @@ required if the certificate chain contains an intermediate certificate.</p>
 
 <h4 id="example-awskms">Example using AWS Key Management Service:</h4>
 
-<p><a href="https://aws.amazon.com/kms/">AWS Key Management Service</a> stores only the private key,
-the certificate must be provided separately. The keystore parameter references the AWS region.
+<p><a href="https://aws.amazon.com/kms/">AWS Key Management Service</a> (KMS) stores only the private key,
+the certificate must be provided separately. The <code>keystore</code> parameter references the AWS region.
 The AWS access key, secret key, and optionally the session token, are concatenated
-and used as the storepass. The alias can specify either the key id or an alias.</p>
+and used as the <code>storepass</code> parameter; if the latter is not provided, the executable is assumed to be running on an AWS EC2 instance,
+and the <a href="https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-metadata.html">IMDSv2</a> service
+is queried to obtain temporary credentials based on the instance profile. In any case, the credentials must allow the following actions:
+<code>kms:ListKeys</code>, <code>kms:DescribeKey</code>, and <code>kms:Sign</code>.
+The <code>alias</code> parameter can specify either the key id or an alias.</p>
 
 <pre>
  jsign --storetype AWS --keystore eu-west-3 \

--- a/jsign-core/src/main/java/net/jsign/KeyStoreType.java
+++ b/jsign-core/src/main/java/net/jsign/KeyStoreType.java
@@ -236,7 +236,7 @@ public enum KeyStoreType {
                 } catch (IOException | CertificateException e) {
                     throw new RuntimeException("Failed to load the certificate from " + params.certfile(), e);
                 }
-            }));
+            }, params.parameterName()));
         }
     },
 

--- a/jsign-core/src/main/java/net/jsign/KeyStoreType.java
+++ b/jsign-core/src/main/java/net/jsign/KeyStoreType.java
@@ -223,9 +223,6 @@ public enum KeyStoreType {
             if (params.keystore() == null) {
                 throw new IllegalArgumentException("keystore " + params.parameterName() + " must specify the AWS region");
             }
-            if (params.storepass() == null) {
-                throw new IllegalArgumentException("storepass " + params.parameterName() + " must specify the AWS credentials: <accessKey>|<secretKey>[|<sessionToken>]");
-            }
             if (params.certfile() == null) {
                 throw new IllegalArgumentException("certfile " + params.parameterName() + " must be set");
             }

--- a/jsign-core/src/main/java/net/jsign/jca/AmazonSigningService.java
+++ b/jsign-core/src/main/java/net/jsign/jca/AmazonSigningService.java
@@ -17,9 +17,7 @@
 package net.jsign.jca;
 
 import java.io.IOException;
-import java.io.InterruptedIOException;
 import java.net.HttpURLConnection;
-import java.net.SocketException;
 import java.net.URL;
 import java.security.GeneralSecurityException;
 import java.security.InvalidAlgorithmParameterException;
@@ -49,6 +47,7 @@ import com.cedarsoftware.util.io.JsonWriter;
 import org.apache.commons.codec.binary.Hex;
 
 import net.jsign.DigestAlgorithm;
+import net.jsign.jca.IMDS2Client.UnreachableServiceException;
 
 import static java.nio.charset.StandardCharsets.*;
 
@@ -112,10 +111,10 @@ public class AmazonSigningService implements SigningService {
         } else {
             try {
                 elements = IMDS2Client.create().getCredentials();
-            } catch (SocketException | InterruptedIOException e) {
+            } catch (UnreachableServiceException e) {
                 throw new IllegalArgumentException("storepass " + parameterName
                         + " must specify the AWS credentials: <accessKey>|<secretKey>[|<sessionToken>]"
-                        + ", when not running from an EC2 instance (IMDSv2 service was unreachable; check the hop limit if containerized)", e);
+                        + ", when not running from an EC2 instance (" + e.getMessage() + ")", e);
             } catch (IOException e) {
                 throw new RuntimeException("an error occurred while fetching temporary credentials from IMDSv2 service", e);
             }

--- a/jsign-core/src/main/java/net/jsign/jca/AmazonSigningService.java
+++ b/jsign-core/src/main/java/net/jsign/jca/AmazonSigningService.java
@@ -91,8 +91,8 @@ public class AmazonSigningService implements SigningService {
     public AmazonSigningService(String region, String credentials, Function<String, Certificate[]> certificateStore) {
         this.certificateStore = certificateStore;
 
-        // parse the credentials
-        String[] elements = credentials.split("\\|", 3);
+        // Obtain the credentials
+        String[] elements = credentials != null ? credentials.split("\\|", 3) : IMDS2Client.create().getCredentials();
         if (elements.length < 2) {
             throw new IllegalArgumentException("Invalid AWS credentials: " + credentials);
         }

--- a/jsign-core/src/main/java/net/jsign/jca/IMDS2Client.java
+++ b/jsign-core/src/main/java/net/jsign/jca/IMDS2Client.java
@@ -1,0 +1,146 @@
+package net.jsign.jca;
+
+import java.io.IOException;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import java.util.Map;
+
+import org.apache.commons.io.IOUtils;
+
+import com.cedarsoftware.util.io.JsonReader;
+
+/**
+ * Client to query the Instance MetaData Service (IMDS) v2 from AWS EC2 instances.
+ * 
+ * @since 5.0
+ * @see <a href="https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/instancedata-data-retrieval.html">Retrieve instance metadata</a>
+ */
+public class IMDS2Client {
+
+    private static final String ROLE_PATTERN = "[-\\w+=,.@]{1,64}";
+    private static final String IMDS_ENDPOINT = "http://169.254.169.254";
+    private static final int TOKEN_TTL_SECONDS = 21600; // 6h (default & max value)
+
+    String apiToken = null;
+
+    private IMDS2Client() {
+    }
+
+    public static IMDS2Client create() {
+        return new IMDS2Client();
+    }
+
+    /**
+     * Get the currently associated role / instance profile for this EC2 instance.
+     * 
+     * @return The name of the role (technically, instance profile) associated with
+     *         the EC2 instance from which this code is run; null if not associated.
+     */
+    public String getInstanceProfileName() {
+        String role = getMetaData("iam/security-credentials", 404);
+        if (role == null) {
+            return null;
+        }
+        if (!role.matches(ROLE_PATTERN)) {
+            throw new RuntimeException("Unable to read the instance profile name");
+        }
+        return role;
+    }
+
+    /**
+     * Query IMDSv2 to obtain credentials to access other AWS services, using the
+     * currently associated role in the instance profile.
+     * 
+     * @return Credentials in the form [accessKeyId, secretAccessKey, token].
+     */
+    public String[] getCredentials() {
+        String role = getInstanceProfileName();
+        if (role == null) {
+            throw new RuntimeException("This EC2 instance seems not to be associated to an instance profile");
+        }
+        return getCredentials(role);
+    }
+
+    /**
+     * Query IMDSv2 to obtain credentials to access other AWS services, using the
+     * specified role.
+     * 
+     * @param role The role / instance profile providing the credentials.
+     * @return Credentials in the form [accessKeyId, secretAccessKey, token].
+     */
+    public String[] getCredentials(String role) {
+        String response = getMetaData("iam/security-credentials/" + role);
+        Map<String, ?> credentials = JsonReader.jsonToMaps(response);
+        return new String[] {
+                (String) credentials.get("AccessKeyId"),
+                (String) credentials.get("SecretAccessKey"),
+                (String) credentials.get("Token")
+        };
+    }
+
+    /**
+     * Obtain a token to authorize queries to IMDSv2.
+     */
+    private String getApiToken() {
+        if (apiToken != null) // TODO: check token TTL if long-lived client
+            return apiToken;
+        try {
+            URL url = new URL(IMDS_ENDPOINT + "/latest/api/token");
+            HttpURLConnection conn = (HttpURLConnection) url.openConnection();
+            conn.setRequestMethod("PUT");
+            conn.setRequestProperty("X-aws-ec2-metadata-token-ttl-seconds", String.valueOf(TOKEN_TTL_SECONDS));
+            int responseCode = conn.getResponseCode();
+            if (responseCode >= 400)
+                throw handleError(conn);
+            apiToken = IOUtils.toString(conn.getInputStream(), StandardCharsets.UTF_8);
+            if (apiToken == null)
+                throw new RuntimeException("Unable to obtain an API token to query the IMDS v2 service");
+            return apiToken;
+        } catch (IOException e) {
+            throw new RuntimeException("Unable to access the IMDS v2 service", e);
+        }
+    }
+
+    /**
+     * Fetch some metadata from IMDS v2 service.
+     * 
+     * @param path             The metadata path to query.
+     * @param noThrowErrorCode Prefer null as a return value (rather than throw) if the HTTP request returns this error code.
+     * @return The resulting metadata, or null if the HTTP request returns with code noThrowErrorCode.
+     */
+    private String getMetaData(String path, int noThrowErrorCode) {
+        try {
+            URL url = new URL(IMDS_ENDPOINT + "/latest/meta-data/" + path);
+            HttpURLConnection conn = (HttpURLConnection) url.openConnection();
+            conn.setRequestProperty("X-aws-ec2-metadata-token", getApiToken());
+            int responseCode = conn.getResponseCode();
+            if (responseCode >= 400) {
+                if (noThrowErrorCode > 0 && responseCode == noThrowErrorCode) {
+                    return null;
+                } else {
+                    throw handleError(conn);
+                }
+            }
+            return IOUtils.toString(conn.getInputStream(), StandardCharsets.UTF_8);
+        } catch (IOException e) {
+            throw new RuntimeException("Unable to access the IMDS v2 service", e);
+        }
+    }
+
+    /**
+     * Fetch some metadata from IMDS v2 service.
+     * 
+     * @param path The metadata path to query.
+     * @return The resulting metadata.
+     */
+    private String getMetaData(String path) {
+        return getMetaData(path, -1);
+    }
+
+    private IOException handleError(HttpURLConnection conn) throws IOException {
+        return new IOException("HTTP Error " + conn.getResponseCode()
+                + (conn.getResponseMessage() != null ? " - " + conn.getResponseMessage() : "") + " (" + conn.getURL()
+                + ")");
+    }
+}

--- a/jsign-core/src/main/java/net/jsign/jca/IMDS2Client.java
+++ b/jsign-core/src/main/java/net/jsign/jca/IMDS2Client.java
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2023 Vincent Malmedy
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package net.jsign.jca;
 
 import java.io.IOException;
@@ -15,14 +31,15 @@ import com.cedarsoftware.util.io.JsonReader;
  * 
  * @since 5.0
  * @see <a href="https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/instancedata-data-retrieval.html">Retrieve instance metadata</a>
+ * @see <a href="https://github.com/aws/aws-sdk-java-v2/blob/master/core/auth/src/main/java/software/amazon/awssdk/auth/credentials/InstanceProfileCredentialsProvider.java">InstanceProfileCredentialsProvider</a>
  */
-public class IMDS2Client {
+class IMDS2Client {
 
     private static final String ROLE_PATTERN = "[-\\w+=,.@]{1,64}";
     private static final String IMDS_ENDPOINT = "http://169.254.169.254";
     private static final int TOKEN_TTL_SECONDS = 21600; // 6h (default & max value)
 
-    String apiToken = null;
+    private String apiToken = null;
 
     private IMDS2Client() {
     }
@@ -37,15 +54,16 @@ public class IMDS2Client {
      * @return The name of the role (technically, instance profile) associated with
      *         the EC2 instance from which this code is run; null if not associated.
      */
-    public String getInstanceProfileName() {
-        String role = getMetaData("iam/security-credentials", 404);
-        if (role == null) {
+    public String getInstanceProfileName() throws IOException {
+        String response = getMetaData("iam/security-credentials", 404);
+        if (response == null) {
             return null;
         }
-        if (!role.matches(ROLE_PATTERN)) {
+        String[] roles = response.trim().split("\n");
+        if (roles.length == 0 || !roles[0].matches(ROLE_PATTERN)) {
             throw new RuntimeException("Unable to read the instance profile name");
         }
-        return role;
+        return roles[0];
     }
 
     /**
@@ -54,10 +72,10 @@ public class IMDS2Client {
      * 
      * @return Credentials in the form [accessKeyId, secretAccessKey, token].
      */
-    public String[] getCredentials() {
+    public String[] getCredentials() throws IOException {
         String role = getInstanceProfileName();
         if (role == null) {
-            throw new RuntimeException("This EC2 instance seems not to be associated to an instance profile");
+            throw new RuntimeException("This EC2 instance seems not to be associated with an instance profile");
         }
         return getCredentials(role);
     }
@@ -69,7 +87,7 @@ public class IMDS2Client {
      * @param role The role / instance profile providing the credentials.
      * @return Credentials in the form [accessKeyId, secretAccessKey, token].
      */
-    public String[] getCredentials(String role) {
+    public String[] getCredentials(String role) throws IOException {
         String response = getMetaData("iam/security-credentials/" + role);
         Map<String, ?> credentials = JsonReader.jsonToMaps(response);
         return new String[] {
@@ -82,24 +100,24 @@ public class IMDS2Client {
     /**
      * Obtain a token to authorize queries to IMDSv2.
      */
-    private String getApiToken() {
-        if (apiToken != null) // TODO: check token TTL if long-lived client
+    private String getApiToken() throws IOException {
+        if (apiToken != null) { // TODO: check token TTL if long-lived client
             return apiToken;
-        try {
-            URL url = new URL(IMDS_ENDPOINT + "/latest/api/token");
-            HttpURLConnection conn = (HttpURLConnection) url.openConnection();
-            conn.setRequestMethod("PUT");
-            conn.setRequestProperty("X-aws-ec2-metadata-token-ttl-seconds", String.valueOf(TOKEN_TTL_SECONDS));
-            int responseCode = conn.getResponseCode();
-            if (responseCode >= 400)
-                throw handleError(conn);
-            apiToken = IOUtils.toString(conn.getInputStream(), StandardCharsets.UTF_8);
-            if (apiToken == null)
-                throw new RuntimeException("Unable to obtain an API token to query the IMDS v2 service");
-            return apiToken;
-        } catch (IOException e) {
-            throw new RuntimeException("Unable to access the IMDS v2 service", e);
         }
+        URL url = new URL(IMDS_ENDPOINT + "/latest/api/token");
+        HttpURLConnection conn = (HttpURLConnection) url.openConnection();
+        conn.setConnectTimeout(3000 /* milliseconds */);
+        conn.setRequestMethod("PUT");
+        conn.setRequestProperty("X-aws-ec2-metadata-token-ttl-seconds", String.valueOf(TOKEN_TTL_SECONDS));
+        int responseCode = conn.getResponseCode();
+        if (responseCode >= 400) {
+            throw handleError(conn); // TODO: check meaning of the error codes
+        }
+        apiToken = IOUtils.toString(conn.getInputStream(), StandardCharsets.UTF_8);
+        if (apiToken == null) {
+            throw new RuntimeException("Unable to obtain an API token to query the IMDS v2 service");
+        }
+        return apiToken;
     }
 
     /**
@@ -109,23 +127,21 @@ public class IMDS2Client {
      * @param noThrowErrorCode Prefer null as a return value (rather than throw) if the HTTP request returns this error code.
      * @return The resulting metadata, or null if the HTTP request returns with code noThrowErrorCode.
      */
-    private String getMetaData(String path, int noThrowErrorCode) {
-        try {
-            URL url = new URL(IMDS_ENDPOINT + "/latest/meta-data/" + path);
-            HttpURLConnection conn = (HttpURLConnection) url.openConnection();
-            conn.setRequestProperty("X-aws-ec2-metadata-token", getApiToken());
-            int responseCode = conn.getResponseCode();
-            if (responseCode >= 400) {
-                if (noThrowErrorCode > 0 && responseCode == noThrowErrorCode) {
-                    return null;
-                } else {
-                    throw handleError(conn);
-                }
+    private String getMetaData(String path, int noThrowErrorCode) throws IOException {
+        URL url = new URL(IMDS_ENDPOINT + "/latest/meta-data/" + path);
+        HttpURLConnection conn = (HttpURLConnection) url.openConnection();
+        conn.setConnectTimeout(10000 /* milliseconds */);
+        conn.setRequestProperty("X-aws-ec2-metadata-token", getApiToken());
+        int responseCode = conn.getResponseCode();
+        if (responseCode >= 400) {
+            // TODO: implement finer error management; see https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/instancedata-data-retrieval.html#instance-metadata-returns
+            if (noThrowErrorCode > 0 && responseCode == noThrowErrorCode) {
+                return null;
+            } else {
+                throw handleError(conn);
             }
-            return IOUtils.toString(conn.getInputStream(), StandardCharsets.UTF_8);
-        } catch (IOException e) {
-            throw new RuntimeException("Unable to access the IMDS v2 service", e);
         }
+        return IOUtils.toString(conn.getInputStream(), StandardCharsets.UTF_8);
     }
 
     /**
@@ -134,7 +150,7 @@ public class IMDS2Client {
      * @param path The metadata path to query.
      * @return The resulting metadata.
      */
-    private String getMetaData(String path) {
+    private String getMetaData(String path) throws IOException {
         return getMetaData(path, -1);
     }
 

--- a/jsign-core/src/test/java/net/jsign/KeyStoreBuilderTest.java
+++ b/jsign-core/src/test/java/net/jsign/KeyStoreBuilderTest.java
@@ -113,8 +113,6 @@ public class KeyStoreBuilderTest {
 
         builder.keystore("eu-west-1");
 
-        builder.storepass("<accessKey>|<secretKey>[|<sessionToken>");
-
         try {
             builder.build();
             fail("Exception not thrown");
@@ -123,6 +121,15 @@ public class KeyStoreBuilderTest {
         }
 
         builder.certfile("keystores/jsign-test-certificate.pem");
+
+        try {
+            builder.build();
+            fail("Exception not thrown");
+        } catch (IllegalArgumentException e) {
+            assertEquals("message", "storepass parameter must specify the AWS credentials: <accessKey>|<secretKey>[|<sessionToken>], when not running from an EC2 instance (IMDSv2 service was unreachable; check the hop limit if containerized)", e.getMessage());
+        }
+
+        builder.storepass("<accessKey>|<secretKey>|<sessionToken>");
 
         KeyStore keystore = builder.build();
         assertNotNull("keystore", keystore);

--- a/jsign-core/src/test/java/net/jsign/KeyStoreBuilderTest.java
+++ b/jsign-core/src/test/java/net/jsign/KeyStoreBuilderTest.java
@@ -113,13 +113,6 @@ public class KeyStoreBuilderTest {
 
         builder.keystore("eu-west-1");
 
-        try {
-            builder.build();
-            fail("Exception not thrown");
-        } catch (IllegalArgumentException e) {
-            assertEquals("message", "storepass parameter must specify the AWS credentials: <accessKey>|<secretKey>[|<sessionToken>]", e.getMessage());
-        }
-
         builder.storepass("<accessKey>|<secretKey>[|<sessionToken>");
 
         try {

--- a/jsign-core/src/test/java/net/jsign/KeyStoreBuilderTest.java
+++ b/jsign-core/src/test/java/net/jsign/KeyStoreBuilderTest.java
@@ -126,7 +126,8 @@ public class KeyStoreBuilderTest {
             builder.build();
             fail("Exception not thrown");
         } catch (IllegalArgumentException e) {
-            assertEquals("message", "storepass parameter must specify the AWS credentials: <accessKey>|<secretKey>[|<sessionToken>], when not running from an EC2 instance (IMDSv2 service was unreachable; check the hop limit if containerized)", e.getMessage());
+            assertTrue("message", e.getMessage().matches(
+                    "storepass parameter must specify the AWS credentials\\: \\<accessKey\\>\\|\\<secretKey\\>\\[\\|\\<sessionToken\\>\\], when not running from an EC2 instance \\(.*\\)"));
         }
 
         builder.storepass("<accessKey>|<secretKey>|<sessionToken>");


### PR DESCRIPTION

This is a solution for #147.
- It does not use AWS Java SDK (too heavy bundle).
- If the `storepass` parameter is not provided, it queries the Instance MetaData Service (IMDS) to get credentials to access AWS KMS.
- I did not reuse the `RESTClient` because it assumes JSON response body, and IMDS explicitly returns text, though it may also sometimes be JSON in that text response...

### Note

If running from within a container hosted on that EC2, the IMDSv2 may not be reachable by default (hop limit set to 1 for the PUT request to obtain the API token). Updating the [hop limit](https://docs.aws.amazon.com/AWSEC2/latest/WindowsGuide/configuring-IMDS-existing-instances.html) to 2 solves the issue, but this is not managed here. Just a clue in case of breaking tests.