### PR TITLE
Support passing of passwords via file

### DIFF
--- a/jsign-cli/src/main/java/net/jsign/JsignCLI.java
+++ b/jsign-cli/src/main/java/net/jsign/JsignCLI.java
@@ -54,6 +54,7 @@ public class JsignCLI {
         options = new Options();
         options.addOption(Option.builder("s").hasArg().longOpt(PARAM_KEYSTORE).argName("FILE").desc("The keystore file, the SunPKCS11 configuration file or the cloud keystore name").type(File.class).build());
         options.addOption(Option.builder().hasArg().longOpt(PARAM_STOREPASS).argName("PASSWORD").desc("The password to open the keystore").build());
+        options.addOption(Option.builder().hasArg().longOpt(PARAM_STOREPASS_FILE).argName("PASSWORD_FILE").desc("The file with the password to open the keystore").build());
         options.addOption(Option.builder().hasArg().longOpt(PARAM_STORETYPE).argName("TYPE")
                 .desc("The type of the keystore:\n"
                         + "- JKS: Java keystore (.jks files)\n"
@@ -72,6 +73,7 @@ public class JsignCLI {
                         + "- HASHICORPVAULT: Google Cloud KMS via HashiCorp Vault\n").build());
         options.addOption(Option.builder("a").hasArg().longOpt(PARAM_ALIAS).argName("NAME").desc("The alias of the certificate used for signing in the keystore.").build());
         options.addOption(Option.builder().hasArg().longOpt(PARAM_KEYPASS).argName("PASSWORD").desc("The password of the private key. When using a keystore, this parameter can be omitted if the keystore shares the same password.").build());
+        options.addOption(Option.builder().hasArg().longOpt(PARAM_KEYPASS_FILE).argName("PASSWORD_FILE").desc("The file with the password of the private key.").build());
         options.addOption(Option.builder().hasArg().longOpt(PARAM_KEYFILE).argName("FILE").desc("The file containing the private key. PEM and PVK files are supported. ").type(File.class).build());
         options.addOption(Option.builder("c").hasArg().longOpt(PARAM_CERTFILE).argName("FILE").desc("The file containing the PKCS#7 certificate chain\n(.p7b or .spc files).").type(File.class).build());
         options.addOption(Option.builder("d").hasArg().longOpt(PARAM_ALG).argName("ALGORITHM").desc("The digest algorithm (SHA-1, SHA-256, SHA-384 or SHA-512)").build());
@@ -105,9 +107,11 @@ public class JsignCLI {
         
         setOption(PARAM_KEYSTORE, helper, cmd);
         setOption(PARAM_STOREPASS, helper, cmd);
+        setOption(PARAM_STOREPASS_FILE, helper, cmd);
         setOption(PARAM_STORETYPE, helper, cmd);
         setOption(PARAM_ALIAS, helper, cmd);
         setOption(PARAM_KEYPASS, helper, cmd);
+        setOption(PARAM_KEYPASS_FILE, helper, cmd);
         setOption(PARAM_KEYFILE, helper, cmd);
         setOption(PARAM_CERTFILE, helper, cmd);
         setOption(PARAM_ALG, helper, cmd);

--- a/jsign-core/src/main/java/net/jsign/SignerHelper.java
+++ b/jsign-core/src/main/java/net/jsign/SignerHelper.java
@@ -28,6 +28,9 @@ import java.net.SocketAddress;
 import java.net.URI;
 import java.net.URL;
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.security.KeyStore;
 import java.security.KeyStoreException;
 import java.security.PrivateKey;
@@ -57,9 +60,11 @@ import net.jsign.timestamp.TimestampingMode;
 class SignerHelper {
     public static final String PARAM_KEYSTORE = "keystore";
     public static final String PARAM_STOREPASS = "storepass";
+    public static final String PARAM_STOREPASS_FILE = "storepass:file";
     public static final String PARAM_STORETYPE = "storetype";
     public static final String PARAM_ALIAS = "alias";
     public static final String PARAM_KEYPASS = "keypass";
+    public static final String PARAM_KEYPASS_FILE = "keypass:file";
     public static final String PARAM_KEYFILE = "keyfile";
     public static final String PARAM_CERTFILE = "certfile";
     public static final String PARAM_ALG = "alg";
@@ -115,6 +120,11 @@ class SignerHelper {
         return this;
     }
 
+    public SignerHelper storepassFile(String storepass) {
+        this.storepass = getFileContent(storepass);
+        return this;
+    }
+
     public SignerHelper storetype(String storetype) {
         ksparams.storetype(storetype);
         return this;
@@ -127,6 +137,11 @@ class SignerHelper {
 
     public SignerHelper keypass(String keypass) {
         ksparams.keypass(keypass);
+        return this;
+    }
+
+    public SignerHelper keypassFile(String keypass) {
+        this.keypass = getFileContent(keypass);
         return this;
     }
 
@@ -223,9 +238,11 @@ class SignerHelper {
         switch (key) {
             case PARAM_KEYSTORE:   return keystore(value);
             case PARAM_STOREPASS:  return storepass(value);
+            case PARAM_STOREPASS_FILE:  return storepassFile(value);
             case PARAM_STORETYPE:  return storetype(value);
             case PARAM_ALIAS:      return alias(value);
             case PARAM_KEYPASS:    return keypass(value);
+            case PARAM_KEYPASS_FILE: return keypassFile(value);
             case PARAM_KEYFILE:    return keyfile(value);
             case PARAM_CERTFILE:   return certfile(value);
             case PARAM_ALG:        return alg(value);
@@ -248,6 +265,19 @@ class SignerHelper {
 
     void setBaseDir(File basedir) {
         ksparams.setBaseDir(basedir);
+    }
+
+    private String getFileContent(String file) {
+        if (file == null) {
+            return null;
+        }
+        Path path = new File(file).toPath();
+        try {
+            byte[] fileContents = Files.readAllBytes(path);
+            return new String(fileContents, StandardCharsets.UTF_8).trim();
+        } catch (IOException e) {
+            throw new IllegalStateException("File '" + path + "' can't be read", e);
+        }
     }
 
     private AuthenticodeSigner build() throws SignerException {


### PR DESCRIPTION
This PR adds support for supplying the password for keystore and private key through a file instead of passing them directly as a parameter to the CLI.

Passing them as a parameter makes them visible to everyone who can run `ps -au`, so pretty much to every user on the system. Using files with tight permissions OTOH can make this a bit more secure.

We're having this change for years already and I'm wondering if this would be applicable for your version as well.