### PR TITLE
fix for crash with small files

### DIFF
--- a/jsign-core/src/main/java/net/jsign/msi/MSIFile.java
+++ b/jsign-core/src/main/java/net/jsign/msi/MSIFile.java
@@ -107,6 +107,9 @@ public class MSIFile implements Signable {
      * @throws IOException if an I/O error occurs
      */
     public static boolean isMSIFile(File file) throws IOException {
+        if (file.length() < 8) {
+            return false;
+        }
         try (DataInputStream in = new DataInputStream(new FileInputStream(file))) {
             return in.readLong() == MSI_HEADER;
         }

--- a/jsign-core/src/test/java/net/jsign/msi/MSIFileTest.java
+++ b/jsign-core/src/test/java/net/jsign/msi/MSIFileTest.java
@@ -16,8 +16,10 @@
 
 package net.jsign.msi;
 
+import java.io.DataOutputStream;
 import java.io.File;
 
+import java.nio.file.Files;
 import org.junit.Test;
 
 import static org.junit.Assert.*;
@@ -35,5 +37,14 @@ public class MSIFileTest {
         MSIFile file = new MSIFile(new File("target/test-classes/minimal.msi"));
         file.close();
         file.close();
+    }
+
+    @Test
+    public void testLessThan8BytesFiles() throws Exception {
+        File smallFile = Files.createTempFile(null, ".msi").toFile();
+        try (DataOutputStream out = new DataOutputStream(Files.newOutputStream(smallFile.toPath()))) {
+            out.writeShort(3);
+        }
+        assertFalse(MSIFile.isMSIFile(smallFile));
     }
 }

--- a/jsign-core/src/test/java/net/jsign/msi/MSIFileTest.java
+++ b/jsign-core/src/test/java/net/jsign/msi/MSIFileTest.java
@@ -20,6 +20,7 @@ import java.io.DataOutputStream;
 import java.io.File;
 
 import java.nio.file.Files;
+import java.nio.file.Path;
 import org.junit.Test;
 
 import static org.junit.Assert.*;
@@ -41,10 +42,10 @@ public class MSIFileTest {
 
     @Test
     public void testLessThan8BytesFiles() throws Exception {
-        File smallFile = Files.createTempFile(null, ".msi").toFile();
-        try (DataOutputStream out = new DataOutputStream(Files.newOutputStream(smallFile.toPath()))) {
+        Path smallFile = Files.createTempFile(null, ".msi");
+        try (DataOutputStream out = new DataOutputStream(Files.newOutputStream(smallFile))) {
             out.writeShort(3);
         }
-        assertFalse(MSIFile.isMSIFile(smallFile));
+        assertFalse(MSIFile.isMSIFile(smallFile.toFile()));
     }
 }


### PR DESCRIPTION
When reading small files, less than 8 bytes, the size of a long, the `DataInputStream.readLong` fails throwing `EOFException`.