### PR TITLE
Fixes #148 -  log4j stderr message about not finding a logging implementation when using jsign CLI

### DIFF
--- a/jsign/src/choco/tools/jsign.cmd
+++ b/jsign/src/choco/tools/jsign.cmd
@@ -3,5 +3,4 @@
 java %JSIGN_OPTS% ^
      -Djava.net.useSystemProxies=true ^
      -Dbasename=jsign ^
-     -Dlog4j2.loggerContextFactory=net.jsign.log4j.simple.SimpleLoggerContextFactory ^
      -jar %~dp0\jsign.jar %*

--- a/jsign/src/deb/data/usr/share/jsign/jsign.sh
+++ b/jsign/src/deb/data/usr/share/jsign/jsign.sh
@@ -3,5 +3,4 @@
 java  $JSIGN_OPTS \
      -Djava.net.useSystemProxies=true \
      -Dbasename=`basename "$0"` \
-     -Dlog4j2.loggerContextFactory=net.jsign.log4j.simple.SimpleLoggerContextFactory \
      -jar /usr/share/jsign/jsign-@VERSION@.jar "$@"

--- a/jsign/src/main/resources/log4j2.component.properties
+++ b/jsign/src/main/resources/log4j2.component.properties
@@ -1,0 +1,1 @@
+log4j2.loggerContextFactory=net.jsign.log4j.simple.SimpleLoggerContextFactory


### PR DESCRIPTION
This fix makes the suggestion from https://github.com/ebourg/jsign/issues/148#issuecomment-1555797023 permanent, by leveraging the log4j2 properties mechanism (instead of relying onto users to do it themselves, struggling with passing Java props to an executable `jar`).

Reference:
* Factory loading shortcut:
https://github.com/apache/logging-log4j2/blob/9c234901e15c9e7f54e527e56d994aa100bc1cbf/log4j-api/src/main/java/org/apache/logging/log4j/LogManager.java#L72-L83

* Properties loading:
https://github.com/apache/logging-log4j2/blob/9c234901e15c9e7f54e527e56d994aa100bc1cbf/log4j-api/src/main/java/org/apache/logging/log4j/util/PropertiesUtil.java#L131-L133

* Log4J properties filename:
https://github.com/apache/logging-log4j2/blob/9c234901e15c9e7f54e527e56d994aa100bc1cbf/log4j-api/src/main/java/org/apache/logging/log4j/util/PropertiesUtil.java#L61
