### PR TITLE
feat: support FIPS endpoints for AWS KMS

### DIFF
--- a/jsign-crypto/src/main/java/net/jsign/jca/AmazonSigningService.java
+++ b/jsign-crypto/src/main/java/net/jsign/jca/AmazonSigningService.java
@@ -81,6 +81,21 @@ public class AmazonSigningService implements SigningService {
         algorithmMapping.put("SHA512withRSA/PSS", "RSASSA_PSS_SHA_512");
     }
 
+     /**
+     * Generates the endpoint URL for the given AWS region.
+     *
+     * @param region the AWS region
+     * @return the endpoint URL
+     */
+    public static String getEndpointUrl(String region) {
+        String useFipsEndpoint = System.getenv("AWS_USE_FIPS_ENDPOINT");
+        if (useFipsEndpoint != null && useFipsEndpoint.equalsIgnoreCase("true")) {
+            return "https://kms-fips." + region + ".amazonaws.com";
+        }
+        
+        return "https://kms." + region + ".amazonaws.com";
+    }
+
     /**
      * Creates a new AWS signing service.
      *
@@ -90,7 +105,7 @@ public class AmazonSigningService implements SigningService {
      * @since 6.0
      */
     public AmazonSigningService(String region, Supplier<AmazonCredentials> credentials, Function<String, Certificate[]> certificateStore) {
-        this(credentials, certificateStore, "https://kms." + region + ".amazonaws.com");
+        this(credentials, certificateStore, getEndpointUrl(region));
     }
 
     /**

--- a/jsign-crypto/src/main/java/net/jsign/jca/AmazonSigningService.java
+++ b/jsign-crypto/src/main/java/net/jsign/jca/AmazonSigningService.java
@@ -88,7 +88,7 @@ public class AmazonSigningService implements SigningService {
      * @return the endpoint URL
      */
     public static String getEndpointUrl(String region) {
-        String useFipsEndpoint = System.getenv("AWS_USE_FIPS_ENDPOINT");
+        String useFipsEndpoint = getenv("AWS_USE_FIPS_ENDPOINT");
         if (useFipsEndpoint != null && useFipsEndpoint.equalsIgnoreCase("true")) {
             return "https://kms-fips." + region + ".amazonaws.com";
         }
@@ -345,5 +345,9 @@ public class AmazonSigningService implements SigningService {
         MessageDigest digest =  DigestAlgorithm.SHA256.getMessageDigest();
         digest.update(data);
         return Hex.toHexString(digest.digest()).toLowerCase();
+    }
+
+    static String getenv(String name) {
+        return System.getenv(name);
     }
 }

--- a/jsign-crypto/src/test/java/net/jsign/jca/AmazonSigningServiceTest.java
+++ b/jsign-crypto/src/test/java/net/jsign/jca/AmazonSigningServiceTest.java
@@ -39,8 +39,12 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+
 import static net.jadler.Jadler.*;
 import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
 
 public class AmazonSigningServiceTest {
 
@@ -91,12 +95,10 @@ public class AmazonSigningServiceTest {
         assertEquals("https://kms.us-west-2.amazonaws.com", defaultEndpoint);
 
         // Test FIPS endpoint
-        try {
-            System.setProperty("AWS_USE_FIPS_ENDPOINT", "true");
+        try (MockedStatic<?> mock = mockStatic(AmazonSigningService.class, CALLS_REAL_METHODS)) {
+            when(AmazonSigningService.getenv("AWS_USE_FIPS_ENDPOINT")).thenReturn("true");
             String fipsEndpoint = AmazonSigningService.getEndpointUrl("us-west-2");
             assertEquals("https://kms-fips.us-west-2.amazonaws.com", fipsEndpoint);
-        } finally {
-            System.clearProperty("AWS_USE_FIPS_ENDPOINT");
         }
     }
 

--- a/jsign-crypto/src/test/java/net/jsign/jca/AmazonSigningServiceTest.java
+++ b/jsign-crypto/src/test/java/net/jsign/jca/AmazonSigningServiceTest.java
@@ -85,6 +85,22 @@ public class AmazonSigningServiceTest {
     }
 
     @Test
+    public void testGetEndpointUrl() throws Exception {
+        // Test default endpoint
+        String defaultEndpoint = AmazonSigningService.getEndpointUrl("us-west-2");
+        assertEquals("https://kms.us-west-2.amazonaws.com", defaultEndpoint);
+
+        // Test FIPS endpoint
+        try {
+            System.setProperty("AWS_USE_FIPS_ENDPOINT", "true");
+            String fipsEndpoint = AmazonSigningService.getEndpointUrl("us-west-2");
+            assertEquals("https://kms-fips.us-west-2.amazonaws.com", fipsEndpoint);
+        } finally {
+            System.clearProperty("AWS_USE_FIPS_ENDPOINT");
+        }
+    }
+
+    @Test
     public void testGetAliasesWithError() {
         onRequest()
                 .havingMethodEqualTo("POST")


### PR DESCRIPTION
AWS services offer FIPS endpoints for some services and regions. For [AWS KMS, all regions support FIPS endpoints](https://docs.aws.amazon.com/general/latest/gr/kms.html#kms_region). When using the CLI, you can normally use `--endpoint-url https://kms-fips.us-east-1.amazonaws.com` and when using any AWS SDK, you can configure the endpoint "mode" by setting `AWS_USE_FIPS_ENDPOINT` in the environment to `true`. 

This change tries to add comperable support for this.

default / current : `kms.us-east-1.amazonaws.com`
fips endpoint: `kms-fips.us-east-1.amazonaws.com`

Details:
https://docs.aws.amazon.com/sdkref/latest/guide/feature-endpoints.html

KMS Service Endpoints:
https://docs.aws.amazon.com/general/latest/gr/kms.html#kms_region