### PR TITLE
Switch to server-side hashing for SignServer support

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -887,17 +887,20 @@ character.</p>
 
 <h4 id="example-signserver">Signing with Keyfactor SignServer</h4>
 
-<p><a href="https://www.signserver.org">SignServer</a> is an on-premises open source signing service developed by Keyfactor.
+<p><a href="https://www.signserver.org">SignServer</a> is an on-premises (or cloud) open source signing service developed by Keyfactor.
 SignServer supports various signing operations handled by signer workers. Jsign requires a
 <a href="https://doc.primekey.com/signserver/signserver-reference/signserver-workers/signserver-signers/plain-signer">Plain Signer</a>
-worker configured with the <code>CLIENTSIDEHASHING</code> or <code>ALLOW_CLIENTSIDEHASHING_OVERRIDE</code> properties
-set to <code>true</code>, and the <code>SIGNATUREALGORITHM</code> property set to <code>NONEwithRSA</code> or
-<code>NONEwithECDSA</code>.</p>
+worker configured with the <code>CLIENTSIDEHASHING</code> property not set or set to <code>false</code> or
+<code>ALLOW_CLIENTSIDEHASHING_OVERRIDE</code> property set to <code>true</code>, and the <code>SIGNATUREALGORITHM</code> property
+set to a supported algorithm that ends in <code>withRSA</code> or <code>withECDSA</code>.
+It is important that the hashing algorithm that is configured for the worker is consistent with the hashing
+algorithm configured for Jsign, otherwise the signature verification will fail.</p>
 
 <p>The authentication is performed by specifying the username/password or the TLS client certificate in the
-<code>storepass</code> parameter. If the TLS client certificate is stored in a password protected keystore, the password
-is specified in the <code>keypass</code> parameter. The <code>keystore</code> parameter references the URL of the
-SignServer REST API. The <code>alias</code> parameter specifies the id or the name of the worker. </p>
+<code>storepass</code> parameter if authentication is necessary. If the TLS client certificate is stored in
+a password protected keystore, the password is specified in the <code>keypass</code> parameter.
+The <code>keystore</code> parameter references the URL of the SignServer REST API. The <code>alias</code> parameter
+specifies the id or the name of the worker. </p>
 
 <p>Authenticating with a username and a password:</p>
 

--- a/jsign-crypto/src/main/java/net/jsign/KeyStoreType.java
+++ b/jsign-crypto/src/main/java/net/jsign/KeyStoreType.java
@@ -561,14 +561,17 @@ public enum KeyStoreType {
     },
 
     /**
-     * Keyfactor SignServer. This keystore requires a Plain Signer worker configured to allow client-side hashing (with
-     * the properties <code>CLIENTSIDEHASHING</code> or <code>ALLOW_CLIENTSIDEHASHING_OVERRIDE</code> set to true), and
-     * the <code>SIGNATUREALGORITHM</code> property set to <code>NONEwithRSA</code> or <code>NONEwithECDSA</code>.
+     * Keyfactor SignServer. This keystore requires a Plain Signer worker configured to allow server-side hashing (with
+     * the property <code>CLIENTSIDEHASHING</code> not set or set to <code>false</code> or
+     * <code>ALLOW_CLIENTSIDEHASHING_OVERRIDE</code> set to <code>true</code>), and the <code>SIGNATUREALGORITHM</code>
+     * property set to a supported algorithm that ends in <code>withRSA</code> or <code>withECDSA</code>.
+     * It is important that the hashing algorithm that is configured for the worker is consistent with the hashing
+     * algorithm configured for Jsign, otherwise the signature verification will fail.
      *
      * <p>The authentication is performed by specifying the username/password or the TLS client certificate in the
-     * storepass parameter. If the TLS client certificate is stored in a password protected keystore, the password is
-     * specified in the keypass parameter. The keystore parameter references the URL of the SignServer REST API. The
-     * alias parameter specifies the id or the name of the worker.</p>
+     * storepass parameter if authentication is necessary. If the TLS client certificate is stored in a password
+     * protected keystore, the password is specified in the keypass parameter. The keystore parameter references
+     * the URL of the SignServer REST API. The alias parameter specifies the id or the name of the worker.</p>
      */
     SIGNSERVER(false, false) {
         @Override


### PR DESCRIPTION
When using for example a Nitrokey HSM 2, client-side hashing seems to not work.
Additionally if `CLIENTSIDEHASHING` was set to `true` in the worker as documented,
the certificate fetching failed.

This PR also uses client-side hashing for the certificate retrieval,
and additionally allows to suffix the alias with `|serverside`, to allow doing
server-side hashing when necessary.
