### PR TITLE
doc: pkcs11 info

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -703,7 +703,7 @@ the name of the one to use.</p>
 The <code>alias</code> represents the name of the certificate used for signing in the <code>keystore</code>.
 
 <pre>
- jsign --storetype PKCS11 --storepass NONE --keystore pkcs11.conf --alias SIGNATURE application.exe
+ jsign --storetype PKCS11 --storepass NONE --keystore pkcs11.conf --alias My-Signing-Cert application.exe
 </pre>
 
 <h4 id="example-awskms">Signing with AWS Key Management Service</h4>

--- a/docs/index.html
+++ b/docs/index.html
@@ -60,7 +60,7 @@ for various build systems (<a href="#maven">Maven</a>, <a href="#gradle">Gradle<
   <li>Keystores supported:
     <ul>
       <li>PKCS#12, JKS and JCEKS files</li>
-      <li>PKCS#11 hardware tokens (<a href="https://www.yubico.com">YubiKey</a>, <a href="https://www.nitrokey.com">Nitrokey</a>, <a href="https://cpl.thalesgroup.com/access-management/authenticators/pki-usb-authentication">SafeNet eToken</a>, etc)</li>
+      <li>PKCS#11 hardware tokens (<a href="https://www.yubico.com">YubiKey</a>, <a href="https://www.nitrokey.com">Nitrokey</a>, <a href="https://cpl.thalesgroup.com/access-management/authenticators/pki-usb-authentication">SafeNet eToken</a>, <a href="https://venafi.com/codesign-protect/">Venafi CodeSign Protect</a>, etc)</li>
       <li>Cloud key management systems:
         <ul>
           <li><a href="https://aws.amazon.com/kms/">AWS KMS</a></li>
@@ -696,6 +696,15 @@ Slot numbers are also accepted (for example <code>9c</code> for the digital sign
 
 <p>If multiple devices are connected, the <code>keystore</code> parameter can be used to specify
 the name of the one to use.</p>
+
+<h4 id="example-pkcs11">Signing with PKCS#11</h4>
+
+<p>A <a href="https://docs.oracle.com/javase/8/docs/technotes/guides/security/p11guide.html#Config">SunPKCS11 configuration file</a> is required. 
+The <code>alias</code> represents the name of the certificate used for signing in the <code>keystore</code>.
+
+<pre>
+ jsign --storetype PKCS11 --storepass NONE --keystore pkcs11.conf --alias SIGNATURE application.exe
+</pre>
 
 <h4 id="example-awskms">Signing with AWS Key Management Service</h4>
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -60,7 +60,7 @@ for various build systems (<a href="#maven">Maven</a>, <a href="#gradle">Gradle<
   <li>Keystores supported:
     <ul>
       <li>PKCS#12, JKS and JCEKS files</li>
-      <li>PKCS#11 hardware tokens (<a href="https://www.yubico.com">YubiKey</a>, <a href="https://www.nitrokey.com">Nitrokey</a>, <a href="https://cpl.thalesgroup.com/access-management/authenticators/pki-usb-authentication">SafeNet eToken</a>, <a href="https://venafi.com/codesign-protect/">Venafi CodeSign Protect</a>, etc)</li>
+      <li>PKCS#11 hardware tokens (<a href="https://www.yubico.com">YubiKey</a>, <a href="https://www.nitrokey.com">Nitrokey</a>, <a href="https://cpl.thalesgroup.com/access-management/authenticators/pki-usb-authentication">SafeNet eToken</a>, etc)</li>
       <li>Cloud key management systems:
         <ul>
           <li><a href="https://aws.amazon.com/kms/">AWS KMS</a></li>


### PR DESCRIPTION
Add Venafi CodeSign Protect as a PKCS#11 provider and provide some basic documentation on how to leverage PKCS#11 for signing.