### PR TITLE
Allow for the certificate file to be passed in through the providerArg parameter

### DIFF
--- a/jsign-crypto/src/main/java/net/jsign/KeyStoreType.java
+++ b/jsign-crypto/src/main/java/net/jsign/KeyStoreType.java
@@ -18,6 +18,7 @@ package net.jsign;
 
 import java.io.File;
 import java.io.FileInputStream;
+import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.net.UnknownServiceException;
 import java.nio.ByteBuffer;
@@ -700,16 +701,21 @@ public enum KeyStoreType {
         }
     }
 
-    private static Function<String, Certificate[]> getCertificateStore(KeyStoreBuilder params) {
+    private static Function<String, Certificate[]> getCertificateStore(KeyStoreBuilder params) throws RuntimeException {
         return alias -> {
             if (alias == null || alias.isEmpty()) {
                 return null;
             }
+            File certificateFile = params.certfile();
 
             try {
-                return CertificateUtils.loadCertificateChain(params.certfile());
-            } catch (IOException | CertificateException e) {
-                throw new RuntimeException("Failed to load the certificate from " + params.certfile(), e);
+                if (!certificateFile.exists()) {
+                    throw new FileNotFoundException("The certfile '" + certificateFile + "' could not be found");
+                }
+                return CertificateUtils.loadCertificateChain(certificateFile);
+            }
+            catch (IOException | CertificateException e) {
+                throw new RuntimeException("Failed to load the certificate from '" + certificateFile + "'", e);
             }
         };
     }

--- a/jsign-crypto/src/test/java/net/jsign/jca/JsignJcaProviderTest.java
+++ b/jsign-crypto/src/test/java/net/jsign/jca/JsignJcaProviderTest.java
@@ -67,6 +67,46 @@ public class JsignJcaProviderTest {
     }
 
     @Test
+    public void testJcaProviderWithKeyStoreAndCertFile() {
+        // Arrange
+        final String keystoreName = "/projects/projName/location/geoLocation/keyRings/keyRingName";
+        final String certFile = "/path/to/certfile";
+
+        // Act
+        final JsignJcaProvider provider = new JsignJcaProvider(keystoreName + "," + certFile);
+
+       // Assert
+        assertEquals(keystoreName, provider.getKeystore());
+        assertEquals(certFile, provider.getCertFile());
+    }
+
+    @Test
+    public void testJcaProviderWithKeyStore() {
+        // Arrange
+        final String keystoreName = "/projects/projName/location/geoLocation/keyRings/keyRingName";
+
+        // Act
+        final JsignJcaProvider provider = new JsignJcaProvider(keystoreName);
+
+        // Assert
+        assertEquals(keystoreName, provider.getKeystore());
+        assertNull("certfile is not null", provider.getCertFile());
+    }
+
+    @Test
+    public void testJcaProviderWithNullConfigArg() {
+        // Arrange
+        final JsignJcaProvider provider = new JsignJcaProvider();
+
+        // Act
+        provider.configure(null);
+
+        // Assert
+        assertNull("keystore is not null", provider.getKeystore());
+        assertNull("certfile is not null", provider.getCertFile());
+    }
+
+    @Test
     public void testKeyStorePKCS11() throws Exception {
         YubikeyTest.assumeYubikey();
 


### PR DESCRIPTION
## Backgroud
Please see the details about this bug [here](https://github.com/ebourg/jsign/issues/271).

## Possible Solution
There are several solutions to this issue but I have opted to go with this one as it involves the smallest possible change.
Currently, the `configArg` is used to pass in the `keyStore` value to the `JsignJcaProvider`. This PR adds the ability to pass in a comma-separated as the `configArg` where the first element is `keyStore` and the second element is the `configArg`.

Also, the `configArg` can:

- be `null`.
- contain just the `keystore`. 
- contain both the `keystore` and `certfile`.

## Testing
See the passed build [here](https://github.com/efetoboreakpoguma/jsign/actions/runs/13033277170).

## Summary
As I said above, this is a **possible solution**. If you decide to go with this approach, we would need to update the docs.