### PR TITLE
Add Scoop package to docs

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -93,6 +93,7 @@ for various build systems (<a href="#maven">Maven</a>, <a href="#gradle">Gradle<
   <li><a href="https://github.com/ebourg/jsign/releases/download/7.0/jsign_7.0_all.deb">DEB package</a> (Debian/Ubuntu)</li>
   <li><a href="https://github.com/ebourg/jsign/releases/download/7.0/jsign-7.0-1.noarch.rpm">RPM package</a> (RedHat/Fedora)</li>
   <li><a href="https://community.chocolatey.org/packages/jsign/">Chocolatey package</a> (Windows)</li>
+  <li><a href="https://scoop.sh/#/apps?q=jsign&id=48a014807579e3b45a673676f26a17fff1f8e961">Scoop package</a> (Windows)</li>
   <li><a href="https://formulae.brew.sh/formula/jsign">Homebrew package</a> (macOS/Linux)</li>
   <li><a href="https://github.com/ebourg/jsign/releases/download/7.0/jsign-7.0.jar">All-in-one JAR</a> (Other systems, Ant task, JCA provider)</li>
 </ul>


### PR DESCRIPTION
I have just added [`jsign`](https://scoop.sh/#/apps?q=jsign&id=48a014807579e3b45a673676f26a17fff1f8e961) to Scoop: https://github.com/ScoopInstaller/Main/pull/6137. It would be nice to have a reference to it on the docs.