### PR TITLE
Quote jsign.jar

### DIFF
--- a/jsign/src/choco/tools/jsign.cmd
+++ b/jsign/src/choco/tools/jsign.cmd
@@ -9,4 +9,4 @@ if exist "C:\Program Files\Yubico\Yubico PIV Tool\bin\" (
 java %JSIGN_OPTS% ^
      -Djava.net.useSystemProxies=true ^
      -Dbasename=jsign ^
-     -jar %~dp0\jsign.jar %*
+     -jar "%~dp0\jsign.jar" %*


### PR DESCRIPTION
Properly handle spaces in filenames.
Related #263