### PR TITLE
Properly handle strings in error field of DigiCert ONE API responses

### DIFF
--- a/jsign-crypto/src/main/java/net/jsign/jca/DigiCertOneSigningService.java
+++ b/jsign-crypto/src/main/java/net/jsign/jca/DigiCertOneSigningService.java
@@ -109,8 +109,14 @@ public class DigiCertOneSigningService implements SigningService {
                     }
                 })
                 .errorHandler(response -> {
-                    Map error = (Map) response.get("error");
-                    return error != null ? error.get("status") + ": " + error.get("message") : JsonWriter.format(response);
+                    Object error = response.get("error");
+                    if (error instanceof Map) {
+                        return ((Map) error).get("status") + ": " + ((Map) error).get("message");
+                    } else if (error instanceof String) {
+                        return (String) error;
+                    } else {
+                        return JsonWriter.format(response);
+                    }
                 });
     }
 


### PR DESCRIPTION
Contrary to what the DigiCert ONE API documentation states and what the Jsign code currently expects, I have observed DigiCert's production endpoint at `https://clientauth.one.digicert.com` to respond with internal server errors with an `error` field that is a plain string, rather than an object containing `status` and `message` fields:

![Packet capture of the HTTP connection showing the observation](https://github.com/user-attachments/assets/ec2e3458-2f44-46a5-854d-89aaf5d89d6b)

This discrepancy causes Jsign to throw the following exception when attempting to sign:

```
jsign: Couldn't sign ./jsign-core/src/test/resources/wineyes.exe
java.lang.ClassCastException: class java.lang.String cannot be cast to class java.util.Map (java.lang.String and java.util.Map are in module java.base of loader 'bootstrap')
        at net.jsign.jca.DigiCertOneSigningService.lambda$new$1(DigiCertOneSigningService.java:112)
        at net.jsign.jca.RESTClient.query(RESTClient.java:190)
        at net.jsign.jca.RESTClient.get(RESTClient.java:70)
        at net.jsign.jca.DigiCertOneSigningService.aliases(DigiCertOneSigningService.java:149)
        at net.jsign.jca.SigningServiceKeyStore.engineAliases(SigningServiceKeyStore.java:54)
        at java.base/java.security.KeyStore.aliases(KeyStore.java:1287)
        at net.jsign.KeyStoreType.getAliases(KeyStoreType.java:685)
        at net.jsign.SignerHelper.build(SignerHelper.java:338)
        at net.jsign.SignerHelper.sign(SignerHelper.java:450)
        at net.jsign.SignerHelper.execute(SignerHelper.java:305)
        at net.jsign.JsignCLI.execute(JsignCLI.java:221)
        at net.jsign.JsignCLI.main(JsignCLI.java:57)
Try `java -jar jsign.jar --help' for more information.
```

This PR improves the error handler in Jsign to be more robust when making sense of the `error` field, correctly handling cases where `error` is a string. If the field is neither a JSON object nor a string, it now falls back to displaying the entire response. For the response above, the resulting exception is much more insightful:

```
jsign: Unable to retrieve DigiCert ONE certificate aliases
java.security.KeyStoreException: Unable to retrieve DigiCert ONE certificate aliases
        at net.jsign.jca.DigiCertOneSigningService.aliases(DigiCertOneSigningService.java:173)
        at net.jsign.jca.SigningServiceKeyStore.engineAliases(SigningServiceKeyStore.java:54)
        at java.base/java.security.KeyStore.aliases(KeyStore.java:1287)
        at net.jsign.KeyStoreType.getAliases(KeyStoreType.java:687)
        at net.jsign.SignerHelper.build(SignerHelper.java:338)
        at net.jsign.SignerHelper.sign(SignerHelper.java:450)
        at net.jsign.SignerHelper.execute(SignerHelper.java:305)
        at net.jsign.JsignCLI.execute(JsignCLI.java:221)
        at net.jsign.JsignCLI.main(JsignCLI.java:57)
Caused by: java.io.IOException: Internal Server Error
        at net.jsign.jca.RESTClient.query(RESTClient.java:190)
        at net.jsign.jca.RESTClient.get(RESTClient.java:70)
        at net.jsign.jca.DigiCertOneSigningService.aliases(DigiCertOneSigningService.java:164)
        ... 8 more
Try `java -jar jsign.jar --help' for more information.
```

Additionally, I've fixed a broken link to the DigiCert ONE REST API documentation I found in the code.