### PR TITLE
Add command to show details about a signed object

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -131,6 +131,7 @@ the all-in-one jar:</p>
   <li><a href="#timestamp-options">timestamp</a></li>
   <li><a href="#extract-options">extract</a></li>
   <li>remove</li>
+  <li><a href="#show">show</a></li>
   <li><a href="#tag-options">tag</a></li>
 </ul>
 
@@ -365,6 +366,27 @@ scan the installdir directory recursively and sign all the DLLs found.</p>
   <dt>--format</dt>
   <dd>The output format of the signature (DER or PEM)</dd>
 </dl>
+
+<br>
+
+<h4 id="show">Show signature</h4>
+
+<p>To check whether a file has been signed and with which certificate, use the show command to list details about any signature present on the file.</p>
+
+<pre>
+  jsign show foo.exe
+  Signature 0
+  Digest Algorithm:   SHA256
+  Digest Value:       c481bb3892d066ffacba0650adaa4c252580b776b1dd6026cf4a8bea6c813939
+  Is Timestamped?     false
+  Certificate
+    Subject:          CN=net.jsign.signing-cert
+    Issuer:           CN=net.jsign.issuing-cert
+    Not Before:       Fri Dec 03 14:34:46 CST 2021
+    Not After:        Wed May 24 14:34:46 CST 2119
+    Expired:          false
+    Serial:           148957645726085760686199624248870688956
+</pre>
 
 <br>
 
@@ -1039,7 +1061,6 @@ are the same as those described above for the command line tool (the long option
                                   --alias &lt;account&gt;/&lt;profile&gt;
                                   ${{ github.workspace }}/dist/application.exe
 </pre>
-
 
 <h3 id="api">API</h3>
 

--- a/jsign-cli/src/main/java/net/jsign/JsignCLI.java
+++ b/jsign-cli/src/main/java/net/jsign/JsignCLI.java
@@ -148,6 +148,10 @@ public class JsignCLI {
         map.put("remove", options);
 
         options = new Options();
+
+        map.put("show", options);
+
+        options = new Options();
         options.addOption(Option.builder().hasArg().longOpt(PARAM_VALUE).argName("VALUE").desc("The value of the unsigned attribute").build());
 
         map.put("tag", options);

--- a/jsign-core/src/main/java/net/jsign/SignerHelper.java
+++ b/jsign-core/src/main/java/net/jsign/SignerHelper.java
@@ -333,6 +333,9 @@ class SignerHelper {
             case "remove":
                 remove(file);
                 break;
+            case "show":
+                show(file);
+                break;
             case "tag":
                 tag(file);
                 break;
@@ -496,6 +499,32 @@ class SignerHelper {
         // todo warn if the hashes don't match
     }
 
+    private void printSignatures(Signable signable) throws IOException {
+        List<CMSSignedData> signatures = signable.getSignatures();
+        for (int i = 0; i < signatures.size(); i++) {
+            CMSSignedData signature = signatures.get(i);
+            SignerInformation signerInformation = signature.getSignerInfos().iterator().next();
+
+            String digestAlgorithmName = new DefaultAlgorithmNameFinder().getAlgorithmName(signerInformation.getDigestAlgorithmID());
+            SignerId signerId = signerInformation.getSID();
+            X509CertificateHolder cert = (X509CertificateHolder) signature.getCertificates().getMatches(signerId).iterator().next();
+
+            byte[] digest = signable.computeDigest(DigestAlgorithm.of(signerInformation.getDigestAlgorithmID().getAlgorithm()));
+
+            System.out.println("Signature " + i);
+            System.out.println("  Digest Algorithm:   " + digestAlgorithmName);
+            System.out.println("  Digest Value:       " + Hex.toHexString(digest));
+            System.out.println("  Is Timestamped?     " + SignatureUtils.isTimestamped(signature));
+            System.out.println("  Certificate");
+            System.out.println("    Subject:          " + cert.getSubject());
+            System.out.println("    Issuer:           " + cert.getIssuer());
+            System.out.println("    Not Before:       " + cert.getNotBefore());
+            System.out.println("    Not After:        " + cert.getNotAfter());
+            System.out.println("    Expired:          " + cert.getNotAfter().before(new Date()));
+            System.out.println("    Serial:           " + cert.getSerialNumber());
+        }
+    }
+
     private void detach(Signable signable, File detachedSignature) throws IOException {
         List<CMSSignedData> signatures = signable.getSignatures();
 
@@ -573,6 +602,20 @@ class SignerHelper {
             throw new SignerException(e.getMessage(), e);
         } catch (Exception e) {
             throw new SignerException("Couldn't remove the signature from " + file, e);
+        }
+    }
+
+    private void show(File file) throws SignerException {
+        if (!file.exists()) {
+            throw new SignerException("Couldn't find " + file);
+        }
+
+        try (Signable signable = Signable.of(file)) {
+            printSignatures(signable);
+        } catch (UnsupportedOperationException | IllegalArgumentException e) {
+            throw new SignerException(e.getMessage(), e);
+        } catch (Exception e) {
+            throw new SignerException("Couldn't show the signatures of" + file, e);
         }
     }
 


### PR DESCRIPTION
It's useful to know whether an executable is already signed and by whom. Either to make sure that you have properly signed it or to check if somebody else has signed it.

Example:

```
> java -jar jsign/target/jsign-7.2-SNAPSHOT.jar show foo.exe
  jsign show foo.exe
  Signature 0
  Digest Algorithm:   SHA256
  Digest Value:       c481bb3892d066ffacba0650adaa4c252580b776b1dd6026cf4a8bea6c813939
  Is Timestamped?     false
  Certificate
    Subject:          CN=net.jsign.signing-cert
    Issuer:           CN=net.jsign.issuing-cert
    Not Before:       Fri Dec 03 14:34:46 CST 2021
    Not After:        Wed May 24 14:34:46 CST 2119
    Expired:          false
    Serial:           148957645726085760686199624248870688956
```