### PR TITLE
Fix 'missing provider' exception for KeyStoreTypes which do not have specific provider

### DIFF
--- a/jsign-crypto/src/main/java/net/jsign/jca/JsignJcaProvider.java
+++ b/jsign-crypto/src/main/java/net/jsign/jca/JsignJcaProvider.java
@@ -201,7 +201,12 @@ public class JsignJcaProvider extends Provider {
             JsignJcaPrivateKey key = (JsignJcaPrivateKey) privateKey;
 
             try {
-                signature = Signature.getInstance(signingAlgorithm, key.getProvider());
+                Provider provider = key.getProvider();
+                if (provider == null) {
+                    signature = Signature.getInstance(signingAlgorithm);
+                } else {
+                    signature = Signature.getInstance(signingAlgorithm, provider);
+                }
             } catch (NoSuchAlgorithmException e) {
                 throw new RuntimeException(e);
             }


### PR DESCRIPTION
Some of the KeyStoreTypes like PKCS12 do not seem to return a provider which lead to the exception below. This small patch seems to fix it.

```
Exception in thread "main" java.lang.IllegalArgumentException: missing provider
	at java.base/sun.security.jca.GetInstance.getService(GetInstance.java:96)
	at java.base/sun.security.jca.GetInstance.getInstance(GetInstance.java:218)
	at java.base/java.security.Signature.getInstance(Signature.java:449)
	at net.jsign.jca.JsignJcaProvider$JsignJcaSignature.engineInitSign(JsignJcaProvider.java:204)
	at java.base/java.security.Signature$Delegate.tryOperation(Signature.java:1322)
	at java.base/java.security.Signature$Delegate.chooseProvider(Signature.java:1276)
	at java.base/java.security.Signature$Delegate.engineInitSign(Signature.java:1360)
	at java.base/java.security.Signature.initSign(Signature.java:636)
```