### PR TITLE
Add support for locating ykcs11 library on macOS

### DIFF
--- a/jsign-crypto/src/main/java/net/jsign/YubiKey.java
+++ b/jsign-crypto/src/main/java/net/jsign/YubiKey.java
@@ -101,14 +101,6 @@ class YubiKey {
         String osname = System.getProperty("os.name");
         String arch = System.getProperty("sun.arch.data.model");
 
-        String pkcs11Module = System.getenv("PKCS11_MODULE");
-        if (pkcs11Module != null && !pkcs11Module.isEmpty()) {
-            File lib = new File(pkcs11Module);
-            if (lib.exists()) {
-                return lib;
-            }
-        }
-
         if (osname.contains("Windows")) {
             String programfiles;
             if ("32".equals(arch) && System.getenv("ProgramFiles(x86)") != null) {

--- a/jsign-crypto/src/main/java/net/jsign/YubiKey.java
+++ b/jsign-crypto/src/main/java/net/jsign/YubiKey.java
@@ -101,6 +101,14 @@ class YubiKey {
         String osname = System.getProperty("os.name");
         String arch = System.getProperty("sun.arch.data.model");
 
+        String pkcs11Module = System.getenv("PKCS11_MODULE");
+        if (pkcs11Module != null && !pkcs11Module.isEmpty()) {
+            File lib = new File(pkcs11Module);
+            if (lib.exists()) {
+                return lib;
+            }
+        }
+
         if (osname.contains("Windows")) {
             String programfiles;
             if ("32".equals(arch) && System.getenv("ProgramFiles(x86)") != null) {

--- a/jsign-crypto/src/main/java/net/jsign/YubiKey.java
+++ b/jsign-crypto/src/main/java/net/jsign/YubiKey.java
@@ -121,14 +121,21 @@ class YubiKey {
             List<String> paths = new ArrayList<>();
             paths.add("/opt/homebrew/lib/libykcs11.dylib");
             paths.add("/usr/local/lib/libykcs11.dylib");
-            
+
+            String dyldLibraryPath = System.getenv("DYLD_LIBRARY_PATH");
+            if (dyldLibraryPath != null) {
+                for (String s : dyldLibraryPath.split(":")) {
+                    paths.add(s + "/libykcs11.dylib");
+                }
+            }
+
             for (String path : paths) {
                 File libykcs11 = new File(path);
                 if (libykcs11.exists()) {
                     return libykcs11;
                 }
             }
-            
+
             return new File("/usr/local/lib/libykcs11.dylib");
 
         } else {

--- a/jsign-crypto/src/main/java/net/jsign/YubiKey.java
+++ b/jsign-crypto/src/main/java/net/jsign/YubiKey.java
@@ -118,6 +118,17 @@ class YubiKey {
             return libykcs11;
 
         } else if (osname.contains("Mac")) {
+            List<String> paths = new ArrayList<>();
+            paths.add("/opt/homebrew/lib/libykcs11.dylib");
+            paths.add("/usr/local/lib/libykcs11.dylib");
+            
+            for (String path : paths) {
+                File libykcs11 = new File(path);
+                if (libykcs11.exists()) {
+                    return libykcs11;
+                }
+            }
+            
             return new File("/usr/local/lib/libykcs11.dylib");
 
         } else {


### PR DESCRIPTION
This pull request enhances the way the `getYkcs11Library()` method in `YubiKey.java` locates the YubiKey PKCS#11 library, making it more flexible and robust, especially for custom and MacOS environments.

Improvements to library discovery:

* Added support for specifying a custom PKCS#11 library path via the `PKCS11_MODULE` environment variable, allowing users to override the default search logic.
* Improved MacOS support by searching multiple common locations for `libykcs11.dylib`, including paths from the `DYLD_LIBRARY_PATH` environment variable, increasing compatibility with different installation methods.