### PR TITLE
Skip LDAP URLs in certificate issuer resolution

### DIFF
--- a/jsign-crypto/src/test/java/net/jsign/CertificateUtilsTest.java
+++ b/jsign-crypto/src/test/java/net/jsign/CertificateUtilsTest.java
@@ -52,6 +52,16 @@ public class CertificateUtilsTest {
     }
 
     @Test
+    public void testGetIssuerCertificateURLSkipsLDAP() throws Exception {
+        Certificate[] chain = CertificateUtils.loadCertificateChain(new File("target/test-classes/keystores/jsign-test-certificate-full-chain-2026.pem"));
+
+        String url = CertificateUtils.getIssuerCertificateURL((X509Certificate) chain[0]);
+        assertNotNull("certificate 1 issuer URL should not be null", url);
+        assertTrue("certificate 1 issuer URL should be HTTP, not LDAP", url.startsWith("http"));
+        assertEquals("certificate 1 issuer", "http://raw.githubusercontent.com/ebourg/jsign/master/jsign-core/src/test/resources/keystores/jsign-code-signing-ca.cer", url);
+    }
+
+    @Test
     public void testGetFullCertificateChain() throws Exception {
         System.setProperty("jsign.cachedir", "target/test-classes/cache/");
 


### PR DESCRIPTION
Fixes #338

Certificates can include Authority Information Access (AIA) extensions with multiple URLs for fetching issuer certificates, including LDAP URLs. The current implementation was attempting to handle all protocols, resulting in an "Unknown protocol ldap" error.

This change adds a test to verify that `CertificateUtils.getIssuerCertificateURL()` correctly skips LDAP URLs and returns HTTP(S) URLs instead. The fix filters out unsupported protocols and uses the first available HTTP URL for issuer certificate retrieval.