### PR TITLE
Fix #345 : allows keystore of types ETOKEN|PKCS11 to be reloaded more than once until an alias is successfully fetched.

### DIFF
--- a/jsign-crypto/src/main/java/net/jsign/KeyStoreBuilder.java
+++ b/jsign-crypto/src/main/java/net/jsign/KeyStoreBuilder.java
@@ -282,7 +282,18 @@ public class KeyStoreBuilder {
      */
     public KeyStore build() throws KeyStoreException {
         validate();
-        return storetype().getKeystore(this, provider());
+        KeyStore keystore = storetype().getKeystore(this, provider());
+        int maxAttempts = storetype().getAliasReloadMaxAttempts();
+        while (!keystore.aliases().hasMoreElements() && maxAttempts-- > 0) {
+            try {
+                Thread.sleep(500);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                throw new KeyStoreException(e);
+            }
+            keystore = storetype().getKeystore(this, provider());
+        }
+        return keystore;
     }
 
     /**

--- a/jsign-crypto/src/main/java/net/jsign/KeyStoreBuilder.java
+++ b/jsign-crypto/src/main/java/net/jsign/KeyStoreBuilder.java
@@ -283,7 +283,11 @@ public class KeyStoreBuilder {
     public KeyStore build() throws KeyStoreException {
         validate();
         KeyStore keystore = storetype().getKeystore(this, provider());
-        int maxAttempts = storetype().getAliasReloadMaxAttempts();
+
+        // On some PKCS#11/eToken configurations, KeyStore.load() may intermittently return a keystore
+        // with an empty alias list on the first attempt, likely due to a timing/race issue in the native token middleware.
+        // Retry to mitigate this (see issue #345).
+        int maxAttempts = 3;
         while (!keystore.aliases().hasMoreElements() && maxAttempts-- > 0) {
             try {
                 Thread.sleep(300);

--- a/jsign-crypto/src/main/java/net/jsign/KeyStoreBuilder.java
+++ b/jsign-crypto/src/main/java/net/jsign/KeyStoreBuilder.java
@@ -286,7 +286,7 @@ public class KeyStoreBuilder {
         int maxAttempts = storetype().getAliasReloadMaxAttempts();
         while (!keystore.aliases().hasMoreElements() && maxAttempts-- > 0) {
             try {
-                Thread.sleep(500);
+                Thread.sleep(300);
             } catch (InterruptedException e) {
                 Thread.currentThread().interrupt();
                 throw new KeyStoreException(e);

--- a/jsign-crypto/src/main/java/net/jsign/KeyStoreType.java
+++ b/jsign-crypto/src/main/java/net/jsign/KeyStoreType.java
@@ -170,7 +170,7 @@ public enum KeyStoreType {
      * in <code>jre/lib/security/java.security</code> or the path to the
      * <a href="https://docs.oracle.com/javase/8/docs/technotes/guides/security/p11guide.html#Config">SunPKCS11 configuration file</a>.
      */
-    PKCS11(false, true) {
+    PKCS11(false, true, 3) {
         @Override
         void validate(KeyStoreBuilder params) {
             if (params.keystore() == null) {
@@ -460,7 +460,7 @@ public enum KeyStoreType {
      * SafeNet eToken
      * This keystore requires the installation of the SafeNet Authentication Client.
      */
-    ETOKEN(false, true) {
+    ETOKEN(false, true, 3) {
         @Override
         Provider getProvider(KeyStoreBuilder params) {
             return SafeNetEToken.getProvider(params.keystore());
@@ -686,9 +686,17 @@ public enum KeyStoreType {
     /** Tells if the keystore is actually a PKCS#11 keystore */
     private final boolean pkcs11;
 
+    /** Returns the max number of attempts to reload the keystore if no alias has been read after {@link #getKeystore(KeyStoreBuilder, Provider)} */
+    private final int aliasReloadMaxAttempts;
+
     KeyStoreType(boolean fileBased, boolean pkcs11) {
+        this(fileBased, pkcs11, 0);
+    }
+
+    KeyStoreType(boolean fileBased, boolean pkcs11, int aliasReloadMaxAttempts) {
         this.fileBased = fileBased;
         this.pkcs11 = pkcs11;
+        this.aliasReloadMaxAttempts = aliasReloadMaxAttempts;
     }
 
     /**
@@ -702,6 +710,13 @@ public enum KeyStoreType {
      */
     Provider getProvider(KeyStoreBuilder params) {
         return null;
+    }
+
+    /**
+     * Returns the {@link #aliasReloadMaxAttempts}
+     */
+    int getAliasReloadMaxAttempts() {
+        return aliasReloadMaxAttempts;
     }
 
     /**

--- a/jsign-crypto/src/main/java/net/jsign/KeyStoreType.java
+++ b/jsign-crypto/src/main/java/net/jsign/KeyStoreType.java
@@ -170,7 +170,7 @@ public enum KeyStoreType {
      * in <code>jre/lib/security/java.security</code> or the path to the
      * <a href="https://docs.oracle.com/javase/8/docs/technotes/guides/security/p11guide.html#Config">SunPKCS11 configuration file</a>.
      */
-    PKCS11(false, true, 3) {
+    PKCS11(false, true) {
         @Override
         void validate(KeyStoreBuilder params) {
             if (params.keystore() == null) {
@@ -460,7 +460,7 @@ public enum KeyStoreType {
      * SafeNet eToken
      * This keystore requires the installation of the SafeNet Authentication Client.
      */
-    ETOKEN(false, true, 3) {
+    ETOKEN(false, true) {
         @Override
         Provider getProvider(KeyStoreBuilder params) {
             return SafeNetEToken.getProvider(params.keystore());
@@ -686,17 +686,9 @@ public enum KeyStoreType {
     /** Tells if the keystore is actually a PKCS#11 keystore */
     private final boolean pkcs11;
 
-    /** Returns the max number of attempts to reload the keystore if no alias has been read after {@link #getKeystore(KeyStoreBuilder, Provider)} */
-    private final int aliasReloadMaxAttempts;
-
     KeyStoreType(boolean fileBased, boolean pkcs11) {
-        this(fileBased, pkcs11, 0);
-    }
-
-    KeyStoreType(boolean fileBased, boolean pkcs11, int aliasReloadMaxAttempts) {
         this.fileBased = fileBased;
         this.pkcs11 = pkcs11;
-        this.aliasReloadMaxAttempts = aliasReloadMaxAttempts;
     }
 
     /**
@@ -710,13 +702,6 @@ public enum KeyStoreType {
      */
     Provider getProvider(KeyStoreBuilder params) {
         return null;
-    }
-
-    /**
-     * Returns the {@link #aliasReloadMaxAttempts}
-     */
-    int getAliasReloadMaxAttempts() {
-        return aliasReloadMaxAttempts;
     }
 
     /**


### PR DESCRIPTION
Fix #345 