### PR TITLE
Fix duplicate slashes in API endpoint paths for DigiCertOneSigningSevice

### DIFF
--- a/jsign-crypto/src/main/java/net/jsign/jca/DigiCertOneSigningService.java
+++ b/jsign-crypto/src/main/java/net/jsign/jca/DigiCertOneSigningService.java
@@ -50,7 +50,7 @@ import net.jsign.KeyStoreBuilder;
  */
 public class DigiCertOneSigningService implements SigningService {
 
-    /** Cache of certificates indexed by id and alias */ 
+    /** Cache of certificates indexed by id and alias */
     private final Map<String, Map<String, ?>> certificates = new HashMap<>();
 
     private final RESTClient client;
@@ -201,7 +201,7 @@ public class DigiCertOneSigningService implements SigningService {
             Map<String, Object> keypair = (Map<String, Object>) certificate.get("keypair");
             String keyId = (String) keypair.get("id");
 
-            Map<String, ?> response = client.get("/keypairs/" + keyId);
+            Map<String, ?> response = client.get("keypairs/" + keyId);
             String algorithm = (String) response.get("key_alg");
 
             SigningServicePrivateKey key = new SigningServicePrivateKey(keyId, algorithm, this);

--- a/jsign-crypto/src/test/java/net/jsign/jca/DigiCertOneSigningServiceTest.java
+++ b/jsign-crypto/src/test/java/net/jsign/jca/DigiCertOneSigningServiceTest.java
@@ -177,7 +177,7 @@ public class DigiCertOneSigningServiceTest {
                 .withBody(new FileReader("target/test-classes/services/digicertone-certificates.json"));
         onRequest()
                 .havingMethodEqualTo("GET")
-                .havingPathEqualTo("/signingmanager/api/v1//keypairs/ea936a8f-446d-8bab-b782-c01e8612bf1e")
+                .havingPathEqualTo("/signingmanager/api/v1/keypairs/ea936a8f-446d-8bab-b782-c01e8612bf1e")
                 .respond()
                 .withStatus(200)
                 .withContentType("application/json")
@@ -203,7 +203,7 @@ public class DigiCertOneSigningServiceTest {
                 .withBody(new FileReader("target/test-classes/services/digicertone-certificates.json"));
         onRequest()
                 .havingMethodEqualTo("GET")
-                .havingPathEqualTo("/signingmanager/api/v1//keypairs/ea936a8f-446d-8bab-b782-c01e8612bf1e")
+                .havingPathEqualTo("/signingmanager/api/v1/keypairs/ea936a8f-446d-8bab-b782-c01e8612bf1e")
                 .respond()
                 .withStatus(404)
                 .withContentType("application/json")


### PR DESCRIPTION
DigiCert has pushed a change to their public API's which are causing requests to endpoints with duplicate slashes to fail and return HTML instead of the expected JSON response. This causes JSIGN to fail when using the DigiCert signing service.

An example of this error is seen below (truncated and censored to not show real data and IDs)
```text
$ jsign --verbose --debug --storetype DIGICERTONE --storepass env:JSIGN_STOREPASS --keystore https://clientauth.demo.one.digicert.com/ --tsaurl http://timestamp.digicert.com/ --alias dummy-alias hello-world-code-signing.exe
GET https://clientauth.demo.one.digicert.com/signingmanager/api/v1/certificates?alias=dummy-alias
x-api-key: ***************************
User-Agent: Jsign (https://ebourg.github.io/jsign/)

Response Code: 200
Content-Type: application/json
Content-Length: 5711
Content:
{...}

GET https://clientauth.demo.one.digicert.com/signingmanager/api/v1//keypairs/450356db-fb2e-471d-a28f-3f05a45f41ba
x-api-key: ***************************
User-Agent: Jsign (https://ebourg.github.io/jsign/)

Response Code: 200
Content-Type: text/html
Content-Length: 2153
Content:
<!DOCTYPE html>
<html lang="en">

<head>
  <meta charset="utf-8" />

  <link rel="icon" href="/signingmanager/favicon.ico">
  <link rel="shortcut icon" href="/signingmanager/favicon.ico" type="image/x-icon" />

  <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
  <meta name="theme-color" content="#000000">

  <title>DigiCert One</title>
  <script type="application/javascript">
    const SCRIPT_URL_KEY = 'tagmanager_script_url';
    const TAG_MANAGER_ENABLED_KEY = 'tagmanager_enabled';

    function loadScript(url) {
        const script = document.createElement('script');
        script.src = url;
        script.type = 'application/javascript';
        document.head.appendChild(script);
    }

    const cachedScriptUrl = localStorage.getItem(SCRIPT_URL_KEY);
    const tagManagerEnabled = localStorage.getItem(TAG_MANAGER_ENABLED_KEY);

    if (cachedScriptUrl && tagManagerEnabled === 'true') {
        loadScript(cachedScriptUrl);
    } else if (!tagManagerEnabled) {
        fetch('/signingmanager/api-ui/v1/environment/config')
            .then(response => response.json())
            .then(data => {
                if (data && (data.tag_manager_script_url || data.tag_manager_enabled)) {
                    if (data.tag_manager_script_url) {
                        localStorage.setItem(SCRIPT_URL_KEY, data.tag_manager_script_url);
                    }
                    localStorage.setItem(TAG_MANAGER_ENABLED_KEY, data.tag_manager_enabled);
                    loadScript(data.tag_manager_script_url);
                }
            })
            .catch(error => {
                console.error('Error fetching JS asset URL:', error);
            });
    }
  </script>
  <script type="module" crossorigin src="/signingmanager/assets/index-CQ32aqML.js"></script>
  <link rel="stylesheet" crossorigin href="/signingmanager/assets/index-CxN7dW9l.css">
<script  src="//[assets.adobedtm.com/80bda08f0087/492a9b22dde0/launch-050249111a08-staging.min.js](http://assets.adobedtm.com/80bda08f0087/492a9b22dde0/launch-050249111a08-staging.min.js)" async></script></head>

<body>
  <noscript>You need to enable JavaScript to run this app.</noscript>
  <div id="root"></div>
</body>

</html>


jsign: Failed to retrieve the private key from the keystore
net.jsign.json-io.util.io.JsonIoException: Unknown JSON value type
line: 1, col: 1
<
        at net.jsign.json-io.util.io.JsonParser.error(JsonParser.java:574)
        at net.jsign.json-io.util.io.JsonParser.readValue(JsonParser.java:292)
        at net.jsign.json-io.util.io.JsonReader.readObject(JsonReader.java:803)
        at net.jsign.json-io.util.io.JsonReader.jsonToJava(JsonReader.java:439)
        at net.jsign.json-io.util.io.JsonReader.jsonToJava(JsonReader.java:453)
        at net.jsign.json-io.util.io.JsonReader.jsonToJava(JsonReader.java:412)
        at net.jsign.jca.RESTClient.query(RESTClient.java:176)
        at net.jsign.jca.RESTClient.get(RESTClient.java:70)
        at net.jsign.jca.DigiCertOneSigningService.getPrivateKey(DigiCertOneSigningService.java:204)
        at net.jsign.jca.SigningServiceKeyStore.engineGetKey(SigningServiceKeyStore.java:36)
        at java.base/java.security.KeyStore.getKey(KeyStore.java:1095)
        at net.jsign.SignerHelper.build(SignerHelper.java:417)
        at net.jsign.SignerHelper.sign(SignerHelper.java:471)
        at net.jsign.SignerHelper.execute(SignerHelper.java:325)
        at net.jsign.JsignCLI.execute(JsignCLI.java:229)
        at net.jsign.JsignCLI.main(JsignCLI.java:58)
Try `jsign --help' for more information.
```