### PR TITLE
Retry flaky connections

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ See https://ebourg.github.io/jsign for more information.
 * The new `--nonProxyHosts` parameter allows to specify hosts that should bypass the HTTP proxy
 * The new `--lazy` signing parameter skips files that are already signed
 * The `remove` command can now filter signatures by digest algorithm and certificate name
-* Timed-out connections to the cloud signing services are now retried
+* Timed-out connections and transient errors (HTTP 429 and 5xx) of the cloud signing services are now retried with an exponential backoff
 * Jsign now retries loading PKCS#11 keystores if the token is not ready (contributed by Saad Benbouzid)
 * Jsign can now open read-only or locked files
 * The error message displayed when the PE certificate table is corrupted has been improved

--- a/jsign-crypto/src/main/java/net/jsign/jca/RESTClient.java
+++ b/jsign-crypto/src/main/java/net/jsign/jca/RESTClient.java
@@ -265,7 +265,6 @@ class RESTClient {
                     wait = getBackoffDelayMs(attempt);
                 }
                 log.fine(String.format("HTTP error %d from %s, retrying in %d ms (attempt %d of %d)", responseCode, url, wait, attempt, retries));
-                conn.disconnect();
                 pause(wait);
             } catch (SocketTimeoutException e) {
                 if (attempt >= retries) {

--- a/jsign-crypto/src/main/java/net/jsign/jca/RESTClient.java
+++ b/jsign-crypto/src/main/java/net/jsign/jca/RESTClient.java
@@ -51,7 +51,7 @@ class RESTClient {
     /** Number of attempts for a request */
     private int retries = 5;
 
-    /** Initial pause between retries in milliseconds, doubled after each attempt on error (not on timeouts) */
+    /** Initial pause between retries in milliseconds, base of the exponential backoff on error (fixed pause on timeouts) */
     private int retryWait = 1000;
 
     /** Connect timeout in milliseconds */
@@ -238,8 +238,9 @@ class RESTClient {
 
     /**
      * Opens a connection to the specified URL and makes several attempts if a timeout occurs
-     * or if the server returns a transient error (rate-limit, bad gateway, etc.).
-     * The pause between the attempts grows exponentially unless the server specifies a <code>Retry-After</code> header.
+     * or if the server returns a retryable error (rate-limit, bad gateway, etc.).
+     * The pause between the attempts grows exponentially up to the connect timeout,
+     * unless the server specifies a <code>Retry-After</code> header.
      * The provided configurator is used to set up the connection before making the request.
      */
     private HttpURLConnection open(URL url, HttpURLConnectionHandler configurator) throws IOException {
@@ -251,7 +252,7 @@ class RESTClient {
                 configurator.handle(conn);
 
                 int responseCode = conn.getResponseCode();
-                if (!isProbablyFlakinessError(responseCode) || attempt >= retries) {
+                if (!isRetryableError(responseCode) || attempt >= retries) {
                     return conn;
                 }
 
@@ -261,7 +262,7 @@ class RESTClient {
                     wait = serverDelay;
                     log.fine("Server returned 'RetryAfter': " + serverDelay);
                 } else {
-                    wait = (long) (retryWait * Math.pow(2, attempt - 1));
+                    wait = getBackoffDelayMs(attempt);
                 }
                 log.fine(String.format("HTTP error %d from %s, retrying in %d ms (attempt %d of %d)", responseCode, url, wait, attempt, retries));
                 conn.disconnect();
@@ -278,12 +279,19 @@ class RESTClient {
         }
     }
 
-    private boolean isProbablyFlakinessError(int responseCode) {
+    private boolean isRetryableError(int responseCode) {
         return responseCode == 429
                 || responseCode == HttpURLConnection.HTTP_INTERNAL_ERROR
                 || responseCode == HttpURLConnection.HTTP_BAD_GATEWAY
                 || responseCode == HttpURLConnection.HTTP_UNAVAILABLE
                 || responseCode == HttpURLConnection.HTTP_GATEWAY_TIMEOUT;
+    }
+
+    /**
+     * Returns the exponential backoff delay in milliseconds for the specified attempt, capped to the connect timeout.
+     */
+    private long getBackoffDelayMs(int attempt) {
+        return (long) Math.min(connectTimeout, retryWait * Math.pow(2, attempt - 1));
     }
 
     /**

--- a/jsign-crypto/src/main/java/net/jsign/jca/RESTClient.java
+++ b/jsign-crypto/src/main/java/net/jsign/jca/RESTClient.java
@@ -51,7 +51,7 @@ class RESTClient {
     /** Number of attempts for a request */
     private int retries = 5;
 
-    /** Pause between retries in milliseconds */
+    /** Initial pause between retries in milliseconds, doubled after each attempt on error (not on timeouts) */
     private int retryWait = 1000;
 
     /** Connect timeout in milliseconds */
@@ -221,7 +221,7 @@ class RESTClient {
             } else {
                 Map<String, Object> map = new HashMap<>();
                 map.put("result", response);
-                return map;  
+                return map;
             }
         } else {
             String error = conn.getErrorStream() != null ? IOUtils.toString(conn.getErrorStream(), StandardCharsets.UTF_8) : "";
@@ -237,37 +237,79 @@ class RESTClient {
     }
 
     /**
-     * Opens a connection to the specified URL and makes several attempts if a timeout occurs.
+     * Opens a connection to the specified URL and makes several attempts if a timeout occurs
+     * or if the server returns a transient error (rate-limit, bad gateway, etc.).
+     * The pause between the attempts grows exponentially unless the server specifies a <code>Retry-After</code> header.
      * The provided configurator is used to set up the connection before making the request.
      */
     private HttpURLConnection open(URL url, HttpURLConnectionHandler configurator) throws IOException {
-        boolean retry = true;
         int attempt = 1;
 
-        HttpURLConnection conn = null;
-
-        while (retry) {
+        while (true) {
+            HttpURLConnection conn = (HttpURLConnection) url.openConnection();
             try {
-                conn = (HttpURLConnection) url.openConnection();
                 configurator.handle(conn);
 
-                conn.getResponseCode();
-                retry = false;
-            } catch (SocketTimeoutException e) {
-                if (attempt++ < retries) {
-                    try {
-                        Thread.sleep(retryWait);
-                        log.fine("Connection to " + url + " timed out, attempt " + attempt + " of " + retries);
-                    } catch (InterruptedException ie) {
-                        Thread.currentThread().interrupt();
-                    }
+                int responseCode = conn.getResponseCode();
+                if (!isProbablyFlakinessError(responseCode) || attempt >= retries) {
+                    return conn;
+                }
+
+                Long serverDelay = getServerRetryDelayMs(conn);
+                long wait;
+                if (serverDelay != null) {
+                    wait = serverDelay;
+                    log.fine("Server returned 'RetryAfter': " + serverDelay);
                 } else {
+                    wait = (long) (retryWait * Math.pow(2, attempt - 1));
+                }
+                log.fine(String.format("HTTP error %d from %s, retrying in %d ms (attempt %d of %d)", responseCode, url, wait, attempt, retries));
+                conn.disconnect();
+                pause(wait);
+            } catch (SocketTimeoutException e) {
+                if (attempt >= retries) {
                     throw (IOException) new SocketTimeoutException("Unable to connect to " + url + " after " + retries + " attempts").initCause(e);
                 }
+
+                log.fine(String.format("Connection to %s timed out, retrying in %d ms (attempt %d of %d)", url, retryWait, attempt, retries));
+                pause(retryWait);
             }
+            attempt++;
+        }
+    }
+
+    private boolean isProbablyFlakinessError(int responseCode) {
+        return responseCode == 429
+                || responseCode == HttpURLConnection.HTTP_INTERNAL_ERROR
+                || responseCode == HttpURLConnection.HTTP_BAD_GATEWAY
+                || responseCode == HttpURLConnection.HTTP_UNAVAILABLE
+                || responseCode == HttpURLConnection.HTTP_GATEWAY_TIMEOUT;
+    }
+
+    /**
+     * Returns the pause in milliseconds requested by the server with the <code>Retry-After</code> header,
+     * or <code>null</code> if the header is absent or unparseable.
+     */
+    private Long getServerRetryDelayMs(HttpURLConnection conn) {
+        String retryAfter = conn.getHeaderField("Retry-After");
+        if (retryAfter == null) {
+            return null;
         }
 
-        return conn;
+        try {
+            return Long.parseLong(retryAfter.trim()) * 1000;
+        } catch (NumberFormatException e) {
+            long date = conn.getHeaderFieldDate("Retry-After", 0);
+            return date > 0 ? Math.max(0, date - System.currentTimeMillis()) : null;
+        }
+    }
+
+    private void pause(long millis) {
+        try {
+            Thread.sleep(millis);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        }
     }
 
     private interface HttpURLConnectionHandler {

--- a/jsign-crypto/src/test/java/net/jsign/jca/RESTClientTest.java
+++ b/jsign-crypto/src/test/java/net/jsign/jca/RESTClientTest.java
@@ -24,11 +24,20 @@ import java.util.concurrent.TimeUnit;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.experimental.theories.DataPoints;
+import org.junit.experimental.theories.FromDataPoints;
+import org.junit.experimental.theories.Theories;
+import org.junit.experimental.theories.Theory;
+import org.junit.runner.RunWith;
 
 import static net.jadler.Jadler.*;
 import static org.junit.Assert.*;
 
+@RunWith(Theories.class)
 public class RESTClientTest {
+
+    @DataPoints("retryableStatus") // Statuscodes in RESTClient.isRetryableError whose requests are retried a certain number of times
+    public static int[] retryableStatus = { 429, 500, 502, 503, 504 };
 
     @Before
     public void setUp() {
@@ -100,5 +109,140 @@ public class RESTClientTest {
         Exception e = assertThrows(IOException.class, () -> client.get("/test"));
         assertEquals("message", "HTTP Error 404 - Not Found (http://localhost:" + port() + "/test)", e.getMessage());
         verifyThatRequest().havingMethodEqualTo("GET").havingPathEqualTo("/test").receivedTimes(1);
+    }
+
+    @Theory
+    public void testRetryOnRetryableResponseSucceeds(@FromDataPoints("retryableStatus") int statusCode) throws Exception {
+        onRequest()
+                .havingMethodEqualTo("GET")
+                .havingPathEqualTo("/test")
+                .respond()
+                .withStatus(statusCode)
+                .thenRespond()
+                .withStatus(200)
+                .withHeader("Content-Type", "application/json")
+                .withBody("{\"status\":\"ok\"}");
+
+        RESTClient client = new RESTClient("http://localhost:" + port());
+        client.retries(3);
+        client.retryWait(10);
+
+        Map<String, ?> response = client.get("/test");
+        assertEquals("ok", response.get("status"));
+        verifyThatRequest().havingMethodEqualTo("GET").havingPathEqualTo("/test").receivedTimes(2);
+    }
+
+    @Test
+    public void testRetryableStatusExhausted() {
+        onRequest()
+                .havingMethodEqualTo("GET")
+                .havingPathEqualTo("/test")
+                .respond()
+                .withStatus(503);
+
+        RESTClient client = new RESTClient("http://localhost:" + port());
+        client.retries(3);
+        client.retryWait(10);
+
+        Exception e = assertThrows(IOException.class, () -> client.get("/test"));
+        assertEquals("message", "HTTP Error 503 - Service Unavailable (http://localhost:" + port() + "/test)", e.getMessage());
+        verifyThatRequest().havingMethodEqualTo("GET").havingPathEqualTo("/test").receivedTimes(3);
+    }
+
+    @Test
+    public void testNoRetryOnClientError() {
+        onRequest()
+                .havingMethodEqualTo("GET")
+                .havingPathEqualTo("/test")
+                .respond()
+                .withStatus(400);
+
+        RESTClient client = new RESTClient("http://localhost:" + port());
+        client.retries(3);
+        client.retryWait(10);
+
+        assertThrows(IOException.class, () -> client.get("/test"));
+        verifyThatRequest().havingMethodEqualTo("GET").havingPathEqualTo("/test").receivedTimes(1);
+    }
+
+    @Test
+    public void testRetryAfterHeaderInSeconds() throws Exception {
+        onRequest()
+                .havingMethodEqualTo("GET")
+                .havingPathEqualTo("/test")
+                .respond()
+                .withStatus(429)
+                .withHeader("Retry-After", "4")
+                .thenRespond()
+                .withStatus(200)
+                .withHeader("Content-Type", "application/json")
+                .withBody("{\"status\":\"ok\"}");
+
+        RESTClient client = new RESTClient("http://localhost:" + port());
+        client.retries(3);
+        client.retryWait(10);
+
+        long elapsed = getAndMeasureElapsedMillis(client);
+
+        assertTrue("Retry handling respects remote's 'Retry-After' header", elapsed >= 4000);
+        verifyThatRequest().havingMethodEqualTo("GET").havingPathEqualTo("/test").receivedTimes(2);
+    }
+
+    @Test
+    public void testExponentialBackoffOnRetry() throws Exception {
+        onRequest()
+                .havingMethodEqualTo("GET")
+                .havingPathEqualTo("/test")
+                .respond()
+                .withStatus(503)
+                .thenRespond()
+                .withStatus(503)
+                .thenRespond()
+                .withStatus(200)
+                .withHeader("Content-Type", "application/json")
+                .withBody("{\"status\":\"ok\"}");
+
+        RESTClient client = new RESTClient("http://localhost:" + port());
+        client.retries(3);
+        client.retryWait(200);
+
+        long elapsed = getAndMeasureElapsedMillis(client);
+
+        assertTrue("retryWait increases exponentially on each attempt (200ms + 400ms)", elapsed >= 600);
+        verifyThatRequest().havingMethodEqualTo("GET").havingPathEqualTo("/test").receivedTimes(3);
+    }
+
+    @Test
+    public void testExponentialBackoffGrowsUntilCap() throws Exception {
+        onRequest()
+                .havingMethodEqualTo("GET")
+                .havingPathEqualTo("/test")
+                .respond()
+                .withStatus(503)
+                .thenRespond()
+                .withStatus(503)
+                .thenRespond()
+                .withStatus(200)
+                .withHeader("Content-Type", "application/json")
+                .withBody("{\"status\":\"ok\"}");
+
+        RESTClient client = new RESTClient("http://localhost:" + port());
+        client.retries(3);
+        client.retryWait(5000);
+        client.connectTimeout(100);
+
+        long elapsed = getAndMeasureElapsedMillis(client);
+
+        assertTrue("retryWait may not exceed the connections timeout", elapsed < 1000);
+        verifyThatRequest().havingMethodEqualTo("GET").havingPathEqualTo("/test").receivedTimes(3);
+    }
+
+    private long getAndMeasureElapsedMillis(RESTClient client) throws IOException {
+        long start = System.currentTimeMillis();
+        Map<String, ?> response = client.get("/test");
+        long elapsed = System.currentTimeMillis() - start;
+
+        assertEquals("ok", response.get("status"));
+        return elapsed;
     }
 }


### PR DESCRIPTION
When using [Azure Artifact Signing] (azure trusted signing) you're currently ewxperiencing degarded performance.  
The api responds slower with each file until it jsign eventually exits.

Eventually we reach `AuthenticodeSignedDataGenerator.getSignerInfo` where where azts dies with a 500 that stops the remaining signatures to be done.  

Our action crashes like this (sorry for the screenshot, our logs expire pretty fast)
<img width="1131" height="404" alt="image" src="https://github.com/user-attachments/assets/e7580738-c0d3-42de-9417-e0a6651f360a" />


This extends the currently implemented retry loop to retry on errors as well not just on timeouts.  
I assume that the remotes would rather send 4xx responses when issues arise with the files or this cli.


[Azure Artifact Signing]: https://learn.microsoft.com/en-us/azure/artifact-signing/